### PR TITLE
Add saving support to the PRC editor

### DIFF
--- a/src/PlasmaShop/Main.h
+++ b/src/PlasmaShop/Main.h
@@ -28,7 +28,7 @@
 #include "GameBrowser.h"
 #include "GameScanner.h"
 
-#define PLASMASHOP_VERSION "3.0 Beta (build 167)"
+#define PLASMASHOP_VERSION "3.0 Beta (build 210)"
 
 class PlasmaShopMain : public QMainWindow {
     Q_OBJECT

--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -40,7 +40,7 @@
 #include "PRP/QCreatable.h"
 #include "QPrcEditor.h"
 
-#define PRPSHOP_VERSION "Build 152"
+#define PRPSHOP_VERSION "Build 210"
 
 PrpShopMain* PrpShopMain::sInstance = NULL;
 PrpShopMain* PrpShopMain::Instance() { return sInstance; }

--- a/src/PrpShop/PRP/QCreatable.cpp
+++ b/src/PrpShop/PRP/QCreatable.cpp
@@ -275,11 +275,6 @@ QCreatable* pqMakeCreatableForm(plCreatable* pCre, QWidget* parent, short forceT
 
     default:
         if ((type & 0x1000) == 0) {
-            QMessageBox msgBox(QMessageBox::Information, parent->tr("Oops"),
-                            parent->tr("No editor is currently available for %1")
-                                      .arg(pqGetFriendlyClassName(type)),
-                            QMessageBox::Ok, parent);
-            msgBox.exec();
             return new QPrcEditor(pCre, parent);
         } else {
             QMessageBox msgBox(QMessageBox::Information, parent->tr("Oops"),

--- a/src/PrpShop/QPrcEditor.h
+++ b/src/PrpShop/QPrcEditor.h
@@ -32,13 +32,14 @@ class QPrcEditor : public QCreatable {
 protected:
     QsciScintilla* fEditor;
     QsciLexerXML* fLexerXML;
+    QAction* fSaveAction;
     bool fDirty;
     bool fLexersInited;
     bool fDoLineNumbers;
 
 public:
     QPrcEditor(plCreatable* pCre, QWidget* parent = NULL);
-    virtual void saveDamage();
+    virtual void saveDamage() { }   // Handled in compilation
 
     virtual QSize sizeHint() const { return QSize(500, 400); }
 
@@ -60,11 +61,19 @@ public slots:
     virtual void performUndo() { fEditor->undo(); }
     virtual void performRedo() { fEditor->redo(); }
 
+    void compilePrc();
+
 signals:
     void statusChanged();
 
 private slots:
     void adjustLineNumbers();
+    void onDirty();
+    void onClean();
+
+protected:
+    virtual void closeEvent(QCloseEvent* event);
+    void loadPrcData();
 };
 
 #endif


### PR DESCRIPTION
Allows one to compile and save PRC from directly within a PRC editor in PrpShop.  There are still some issues in HSPlasma with PRC compilation on an existing object (instead of creating a new one), but this should at least take care of the most immediate need of being able to save PRC.
