### PR TITLE
Implement dynamic version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,20 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_C_FLAGS "${WARNING_FLAGS} ${CMAKE_C_FLAGS}")
 endif()
 
+# Get the version number from git
+set(PlasmaShop_VERSION "3.0-untracked")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    find_program(GIT_EXECUTABLE NAMES git git.cmd)
+    mark_as_advanced(GIT_EXECUTABLE)
+    if(GIT_EXECUTABLE)
+        execute_process(COMMAND ${GIT_EXECUTABLE} describe --dirty
+                        OUTPUT_VARIABLE PlasmaShop_VERSION
+                        OUTPUT_STRIP_TRAILING_WHITESPACE
+                        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+    endif()
+endif()
+add_definitions(-DPLASMASHOP_VERSION="${PlasmaShop_VERSION}")
+
 add_subdirectory(src/PlasmaShop)
 add_subdirectory(src/PrpShop)
 add_subdirectory(src/VaultShop)

--- a/src/PlasmaShop/Main.h
+++ b/src/PlasmaShop/Main.h
@@ -28,8 +28,6 @@
 #include "GameBrowser.h"
 #include "GameScanner.h"
 
-#define PLASMASHOP_VERSION "3.0 Beta (build 229)"
-
 class PlasmaShopMain : public QMainWindow {
     Q_OBJECT
 

--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -42,8 +42,6 @@
 #include "PRP/QCreatable.h"
 #include "QPrcEditor.h"
 
-#define PRPSHOP_VERSION "Build 233"
-
 PrpShopMain* PrpShopMain::sInstance = NULL;
 PrpShopMain* PrpShopMain::Instance() { return sInstance; }
 plResManager* PrpShopMain::ResManager() { return &sInstance->fResMgr; }
@@ -56,7 +54,7 @@ PrpShopMain::PrpShopMain()
     sInstance = this;
 
     // Basic Form Settings
-    setWindowTitle("PrpShop " PRPSHOP_VERSION);
+    setWindowTitle("PrpShop " PLASMASHOP_VERSION);
     setWindowIcon(QIcon(":/res/PrpShop.svg"));
     setDockOptions(QMainWindow::AnimatedDocks);
 

--- a/src/VaultShop/Main.cpp
+++ b/src/VaultShop/Main.cpp
@@ -101,7 +101,7 @@ void VaultShopMain::SaveInfo::save()
 VaultShopMain::VaultShopMain()
 {
     // Basic Form Settings
-    setWindowTitle("VaultShop 1.1");
+    setWindowTitle("VaultShop " PLASMASHOP_VERSION);
     //setWindowIcon(QIcon(":/res/VaultShop.png"));
 
     // Set up actions


### PR DESCRIPTION
Here is my approach of a simple implementation of what we have discussed in #26. When building from a git repository the version number will be fetched using `git describe`.

![img](https://dl.dropboxusercontent.com/u/743689/PlasmaShopRevPR.jpg)

This requires a tag to work or git describe will return a fatal error. For testing I created a local tag. Currently this only supports annotated tags but support for lightweight tags can be added by calling `git describe --tags`.
