### PR TITLE
Save Mipmaps using QImage

### DIFF
--- a/src/PrpShop/PRP/Surface/QMipmap.h
+++ b/src/PrpShop/PRP/Surface/QMipmap.h
@@ -36,8 +36,14 @@ public:
     virtual ~QTextureBox();
     void setTexture(plMipmap* tex, int level = 0);
 
+public slots:
+    void saveAs();
+
 protected:
     virtual void paintEvent(QPaintEvent*);
+
+signals:
+    void textureChanged(bool success);
 };
 
 class QMipmap_Preview : public QCreatable {


### PR DESCRIPTION
When displaying the Mipmap preview we are already decompressing and converting the texture to a QImage. Let's use that to allow saving textures to Qt image formats like PNG.
This might help people who just want a specific texture to work with and do not care whether it is a real texture export into a DDS or JPEG(s).

I've chosen to go the cleanest way without having to touch a lot of code and added a "Save As..." link to the preview. As a bonus this cleans up some QSettings copy-paste redundancy.
