### PR TITLE
Linking Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(PlasmaShop)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.11.2)
 
 find_package(HSPlasma REQUIRED)
 

--- a/QScintilla/Qt4Qt5/CMakeLists.txt
+++ b/QScintilla/Qt4Qt5/CMakeLists.txt
@@ -97,7 +97,7 @@ add_definitions(-DQSCINTILLA_MAKE_DLL -DQT -DSCI_LEXER)
 
 add_library(qscintilla2-ps3 STATIC ${QScintilla_Sources} ${QScintilla_MOC})
 if(PS_USE_QT5)
-    qt5_use_modules(qscintilla2-ps3 Core Widgets PrintSupport)
+    target_link_libraries(qscintilla2-ps3 Qt5::Widgets Qt5::PrintSupport)
 elseif(PS_USE_QT4)
     target_link_libraries(qscintilla2-ps3 ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY})
 endif()

--- a/src/PlasmaShop/CMakeLists.txt
+++ b/src/PlasmaShop/CMakeLists.txt
@@ -112,8 +112,7 @@ add_executable(PlasmaShop WIN32 MACOSX_BUNDLE
                ${PlasmaShop_Sources} ${pycdc_Sources} ${pycdc_GeneratedSources}
                ${PlasmaShop_MOC} ${PlasmaShop_RCC})
 if(PS_USE_QT5)
-    qt5_use_modules(PlasmaShop Core Widgets)
-    target_link_libraries(PlasmaShop ${Qt5Core_QTMAIN_LIBRARIES})
+    target_link_libraries(PlasmaShop Qt5::Widgets)
 elseif(PS_USE_QT4)
     target_link_libraries(PlasmaShop ${QT_QTMAIN_LIBRARY} ${QT_QTCORE_LIBRARY}
                                      ${QT_QTGUI_LIBRARY})

--- a/src/PrpShop/CMakeLists.txt
+++ b/src/PrpShop/CMakeLists.txt
@@ -162,8 +162,7 @@ set(QT_QTOPENGL_LIB_DEPENDENCIES ${OPENGL_glu_LIBRARY} ${OPENGL_gl_LIBRARY})
 add_executable(PrpShop WIN32 MACOSX_BUNDLE
                ${PrpShop_Sources} ${PrpShop_MOC} ${PrpShop_RCC})
 if(PS_USE_QT5)
-    qt5_use_modules(PrpShop Core Widgets OpenGL)
-    target_link_libraries(PrpShop ${Qt5Core_QTMAIN_LIBRARIES})
+    target_link_libraries(PrpShop Qt5::Widgets Qt5::OpenGL)
 elseif(PS_USE_QT4)
     target_link_libraries(PrpShop ${QT_QTMAIN_LIBRARY} ${QT_QTCORE_LIBRARY}
                                   ${QT_QTGUI_LIBRARY} ${QT_QTOPENGL_LIBRARY})

--- a/src/VaultShop/CMakeLists.txt
+++ b/src/VaultShop/CMakeLists.txt
@@ -61,8 +61,7 @@ include_directories("${HSPlasma_INCLUDE_DIRS}")
 add_executable(VaultShop WIN32 MACOSX_BUNDLE
                ${VaultShop_Sources} ${VaultShop_MOC} ${VaultShop_RCC})
 if(PS_USE_QT5)
-    qt5_use_modules(VaultShop Core Widgets)
-    target_link_libraries(VaultShop ${Qt5Core_QTMAIN_LIBRARIES})
+    target_link_libraries(VaultShop Qt5::Widgets)
 elseif(PS_USE_QT4)
     target_link_libraries(VaultShop ${QT_QTMAIN_LIBRARY} ${QT_QTCORE_LIBRARY}
                                     ${QT_QTGUI_LIBRARY})


### PR DESCRIPTION
I have been compiling PlasmaShop a few times, recently, and generating with CMake always threw a shiny red list of warnings against me. (At least when compiling with Qt5.)

I took the liberty of bumping the required CMake version to 2.8.11.2 and updated the way of linking Qt5.
CMake was very happy.
