### PR TITLE
Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ if(WIN32)
     add_definitions(-DPLAT_FONT="Courier New")
 else()
     add_definitions(-DPLAT_FONT="Monospace")
-    add_definitions(-DDATA_PATH="/usr/local/share/PlasmaShop")
 endif()
 
 # do this after QScintilla - it generates tons of warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ endif()
 add_definitions(-DPLASMASHOP_VERSION="${PlasmaShop_VERSION}")
 
 include_directories(${STRING_THEORY_INCLUDE_DIRS})
+include_directories("${PROJECT_SOURCE_DIR}/src")
 
 add_subdirectory(src/PlasmaShop)
 add_subdirectory(src/PrpShop)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,40 +1,13 @@
 project(PlasmaShop)
 cmake_minimum_required(VERSION 2.8.11.2)
 
+set(CMAKE_AUTOMOC TRUE)
+
 find_package(HSPlasma REQUIRED)
 find_package(string_theory REQUIRED)
-
-option(PlasmaShop_FORCE_QT4 "Force Qt4 build even if Qt5 can be found" OFF)
-if(NOT PlasmaShop_FORCE_QT4)
-    find_package(Qt5Core)
-endif()
-
-if(Qt5Core_FOUND)
-    set(PS_USE_QT5 TRUE)
-    macro(QTX_WRAP_CPP dest files)
-        qt5_wrap_cpp(${dest} ${files})
-    endmacro()
-    macro(QTX_ADD_RESOURCES dest files)
-        qt5_add_resources(${dest} ${files})
-    endmacro()
-else()
-    ### UGLY:  Qt4's CMake module can only be run once.  Therefore, we must
-    ###        find all required modules now, as subsequent finds won't work.
-    ###        Now I understand better why Qt5 split them up more sanely
-    find_package(Qt4 COMPONENTS QtCore QtGui QtOpenGL)
-    if(QT4_FOUND)
-        set(PS_USE_QT4 TRUE)
-        include(${QT_USE_FILE})
-        macro(QTX_WRAP_CPP dest files)
-            qt4_wrap_cpp(${dest} ${files})
-        endmacro()
-        macro(QTX_ADD_RESOURCES dest files)
-            qt4_add_resources(${dest} ${files})
-        endmacro()
-    else()
-        message(FATAL_ERROR "Either Qt4 or Qt5 is required to compile PlasmaShop")
-    endif()
-endif()
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Gui REQUIRED)
+find_package(Qt5Widgets REQUIRED)
 
 if(MSVC)
     add_definitions("/D_CRT_SECURE_NO_WARNINGS")
@@ -72,11 +45,8 @@ endif()
 add_definitions(-DPLASMASHOP_VERSION="${PlasmaShop_VERSION}")
 
 include_directories(${STRING_THEORY_INCLUDE_DIRS})
-include_directories("${PROJECT_SOURCE_DIR}/src")
 
-add_subdirectory(src/PlasmaShop)
-add_subdirectory(src/PrpShop)
-add_subdirectory(src/VaultShop)
+add_subdirectory(src)
 
 if(WIN32)
     add_subdirectory(icons/win32)

--- a/QScintilla/Qt4Qt5/CMakeLists.txt
+++ b/QScintilla/Qt4Qt5/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(QScintilla_MOC_Headers
+set(QScintilla_Headers
     ./QsciPS3/qsciscintilla.h
     ./QsciPS3/qsciscintillabase.h
     ./QsciPS3/qsciabstractapis.h
@@ -91,14 +91,10 @@ set(QScintilla_Sources
     ../src/XPM.cpp
 )
 
-if(PS_USE_QT5)
-    find_package(Qt5Widgets REQUIRED)
-    find_package(Qt5PrintSupport REQUIRED)
-    if(APPLE)
-        find_package(Qt5MacExtras REQUIRED)
-    endif()
+find_package(Qt5PrintSupport REQUIRED)
+if(APPLE)
+    find_package(Qt5MacExtras REQUIRED)
 endif()
-qtx_wrap_cpp(QScintilla_MOC "${QScintilla_MOC_Headers}")
 
 include_directories("${PROJECT_SOURCE_DIR}/QScintilla/Qt4Qt5")
 include_directories("${PROJECT_SOURCE_DIR}/QScintilla/include")
@@ -107,12 +103,8 @@ include_directories("${PROJECT_SOURCE_DIR}/QScintilla/src")
 
 add_definitions(-DQT -DSCINTILLA_QT -DSCI_LEXER)
 
-add_library(qscintilla2-ps3 STATIC ${QScintilla_Sources} ${QScintilla_MOC})
-if(PS_USE_QT5)
-    target_link_libraries(qscintilla2-ps3 Qt5::Widgets Qt5::PrintSupport)
-    if(APPLE)
-        target_link_libraries(qscintilla2-ps3 Qt5::MacExtras)
-    endif()
-elseif(PS_USE_QT4)
-    target_link_libraries(qscintilla2-ps3 ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY})
+add_library(qscintilla2-ps3 STATIC ${QScintilla_Sources} ${QScintilla_Headers})
+target_link_libraries(qscintilla2-ps3 Qt5::Widgets Qt5::PrintSupport)
+if(APPLE)
+    target_link_libraries(qscintilla2-ps3 Qt5::MacExtras)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,39 @@
+include_directories("${PROJECT_SOURCE_DIR}/src")
+
+include_directories("${PROJECT_SOURCE_DIR}/src/3rdParty")
+include_directories("${HSPlasma_INCLUDE_DIRS}")
+
+set(PSCommon_Headers
+    QPlasma.h
+    QColorEdit.h
+    QHexWidget.h
+    QLinkLabel.h
+    QNumerics.h
+)
+
+set(PSCommon_Sources
+    QColorEdit.cpp
+    QHexWidget.cpp
+    QLinkLabel.cpp
+    QNumerics.cpp
+)
+
+add_library(PSCommon STATIC ${PSCommon_Headers} ${PSCommon_Sources})
+target_link_libraries(PSCommon HSPlasma Qt5::Widgets)
+
+if(NOT WIN32 AND NOT APPLE)
+    set(PSIconLoader_Headers
+        3rdParty/qticonloader.h
+    )
+
+    set(PSIconLoader_Sources
+        3rdParty/qticonloader.cpp
+    )
+
+    add_library(PSIconLoader STATIC ${PSIconLoader_Headers} ${PSIconLoader_Sources})
+    target_link_libraries(PSIconLoader Qt5::Gui)
+endif()
+
+add_subdirectory(PlasmaShop)
+add_subdirectory(PrpShop)
+add_subdirectory(VaultShop)

--- a/src/PlasmaShop/CMakeLists.txt
+++ b/src/PlasmaShop/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(PlasmaShop_MOC_Headers
+set(PlasmaShop_Headers
     Main.h
     OptionsDialog.h
     GameBrowser.h
@@ -27,6 +27,18 @@ set(PlasmaShop_Sources
 # include pycdc sources
 set(pycdc_SOURCE_DIR ${PROJECT_SOURCE_DIR}/pycdc)
 set(pycdc_BINARY_DIR ${PROJECT_BINARY_DIR}/pycdc)
+set(pycdc_Headers
+    ${pycdc_SOURCE_DIR}/ASTNode.h
+    ${pycdc_SOURCE_DIR}/ASTree.h
+    ${pycdc_SOURCE_DIR}/bytecode.h
+    ${pycdc_SOURCE_DIR}/data.h
+    ${pycdc_SOURCE_DIR}/pyc_code.h
+    ${pycdc_SOURCE_DIR}/pyc_module.h
+    ${pycdc_SOURCE_DIR}/pyc_numeric.h
+    ${pycdc_SOURCE_DIR}/pyc_object.h
+    ${pycdc_SOURCE_DIR}/pyc_sequence.h
+    ${pycdc_SOURCE_DIR}/pyc_string.h
+)
 set(pycdc_Sources
     ${pycdc_SOURCE_DIR}/ASTNode.cpp
     ${pycdc_SOURCE_DIR}/ASTree.cpp
@@ -93,40 +105,25 @@ add_custom_command(OUTPUT ${pycdc_GeneratedSources}
                            create-bytes-source-dir
                    WORKING_DIRECTORY ${pycdc_SOURCE_DIR}/bytes)
 
-if(NOT WIN32 AND NOT APPLE)
-    set(PlasmaShop_Sources "${PlasmaShop_Sources}"
-        ../3rdParty/qticonloader.cpp
-    )
-endif()
-
 if(WIN32)
     set(PlasmaShop_Sources ${PlasmaShop_Sources} res/PlasmaShop.rc)
 endif()
 
-if(PS_USE_QT5)
-    find_package(Qt5Widgets REQUIRED)
-endif()
-
 # generate rules for building source files from the resources
-qtx_add_resources(PlasmaShop_RCC images.qrc)
-# generate rules for building source files that moc generates
-qtx_wrap_cpp(PlasmaShop_MOC "${PlasmaShop_MOC_Headers}")
+qt5_add_resources(PlasmaShop_RCC images.qrc)
 
-include_directories("${PROJECT_SOURCE_DIR}/src/3rdParty")
 include_directories("${PROJECT_SOURCE_DIR}/QScintilla/Qt4Qt5")
 include_directories("${pycdc_SOURCE_DIR}")
-include_directories("${HSPlasma_INCLUDE_DIRS}")
 
 add_executable(PlasmaShop WIN32 MACOSX_BUNDLE
-               ${PlasmaShop_Sources} ${pycdc_Sources} ${pycdc_GeneratedSources}
-               ${PlasmaShop_MOC} ${PlasmaShop_RCC})
-if(PS_USE_QT5)
-    target_link_libraries(PlasmaShop Qt5::Widgets)
-elseif(PS_USE_QT4)
-    target_link_libraries(PlasmaShop ${QT_QTMAIN_LIBRARY} ${QT_QTCORE_LIBRARY}
-                                     ${QT_QTGUI_LIBRARY})
-endif()
+               ${PlasmaShop_Headers} ${PlasmaShop_Sources}
+               ${pycdc_Headers} ${pycdc_Sources} ${pycdc_GeneratedSources}
+               ${PlasmaShop_RCC})
+target_link_libraries(PlasmaShop Qt5::Widgets)
 target_link_libraries(PlasmaShop qscintilla2-ps3 HSPlasma)
+if(NOT WIN32 AND NOT APPLE)
+    target_link_libraries(PlasmaShop PSIconLoader)
+endif()
 
 if(WIN32)
     target_link_libraries(PlasmaShop shell32)

--- a/src/PlasmaShop/Main.cpp
+++ b/src/PlasmaShop/Main.cpp
@@ -30,7 +30,7 @@
 #include <Debug/plDebug.h>
 
 #include "Main.h"
-#include "../QPlasma.h"
+#include "QPlasma.h"
 #include "OptionsDialog.h"
 #include "QPlasmaTextDoc.h"
 #include "QPlasmaPakFile.h"

--- a/src/PlasmaShop/OptionsDialog.cpp
+++ b/src/PlasmaShop/OptionsDialog.cpp
@@ -31,7 +31,7 @@
 #include <QPushButton>
 #include <QFileDialog>
 #include <QFontDialog>
-#include "../QPlasma.h"
+#include "QPlasma.h"
 
 #ifdef Q_OS_WIN
     // For SHGetFolderPath

--- a/src/PlasmaShop/OptionsDialog.cpp
+++ b/src/PlasmaShop/OptionsDialog.cpp
@@ -273,17 +273,6 @@ QString GetPSBinPath(QString filename)
     return QDir(s_binBasePath).absoluteFilePath(filename);
 }
 
-QString GetPSDataPath(QString filename)
-{
-#ifdef Q_OS_WIN
-    // Windows stores everything in Program Files
-    return QDir(s_binBasePath).absoluteFilePath(filename);
-#else
-    // POSIX stores data in a separate location
-    return QDir(DATA_PATH).absoluteFilePath(filename);
-#endif
-}
-
 QString GetAppDataPath()
 {
 #ifdef Q_OS_WIN

--- a/src/PlasmaShop/OptionsDialog.h
+++ b/src/PlasmaShop/OptionsDialog.h
@@ -63,7 +63,6 @@ private slots:
 
 // Magic for getting special paths
 QString GetPSBinPath(QString filename);
-QString GetPSDataPath(QString filename);
 QString GetAppDataPath();
 QString GetDocumentsPath();
 

--- a/src/PlasmaShop/QPlasmaDevModeDat.cpp
+++ b/src/PlasmaShop/QPlasmaDevModeDat.cpp
@@ -19,7 +19,7 @@
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QScrollArea>
-#include "../QPlasma.h"
+#include "QPlasma.h"
 
 /* QPlasmaDevModeDat */
 QPlasmaDevModeDat::QPlasmaDevModeDat(QWidget* parent)

--- a/src/PlasmaShop/QPlasmaPakFile.cpp
+++ b/src/PlasmaShop/QPlasmaPakFile.cpp
@@ -24,7 +24,7 @@
 #include <QFileDialog>
 #include <QSettings>
 #include <qticonloader.h>
-#include "../QPlasma.h"
+#include "QPlasma.h"
 
 #include <ASTree.h>
 #include <data.h>

--- a/src/PlasmaShop/QPlasmaSumFile.cpp
+++ b/src/PlasmaShop/QPlasmaSumFile.cpp
@@ -26,7 +26,7 @@
 #include <QSettings>
 #include <QCryptographicHash>
 #include <qticonloader.h>
-#include "../QPlasma.h"
+#include "QPlasma.h"
 
 /* SumData */
 void SumData::read(hsStream* S)

--- a/src/PlasmaShop/QPlasmaTextDoc.cpp
+++ b/src/PlasmaShop/QPlasmaTextDoc.cpp
@@ -21,7 +21,7 @@
 #include <qticonloader.h>
 #include <Stream/plEncryptedStream.h>
 #include <Stream/hsElfStream.h>
-#include "../QPlasma.h"
+#include "QPlasma.h"
 
 #define MARGIN_LINES 0
 #define MARGIN_FOLDERS 1

--- a/src/PlasmaShop/QPlasmaTextDoc.cpp
+++ b/src/PlasmaShop/QPlasmaTextDoc.cpp
@@ -471,7 +471,8 @@ bool QPlasmaTextDoc::loadFile(QString filename)
         fEditor->setReadOnly(true);
     } else if (plEncryptedStream::IsFileEncrypted(filename.toUtf8().data())) {
         plEncryptedStream S(PlasmaVer::pvUnknown);
-        if (!S.open(filename.toUtf8().data(), fmRead, plEncryptedStream::kEncAuto)) return false;
+        if (!S.open(filename.toUtf8().data(), fmRead, plEncryptedStream::kEncAuto))
+            return false;
         if (S.getEncType() == plEncryptedStream::kEncDroid) {
             if (!GetEncryptionKeyFromUser(this, fDroidKey))
                 return false;
@@ -486,7 +487,8 @@ bool QPlasmaTextDoc::loadFile(QString filename)
         fEditor->setText(LoadData(&S, fEncoding));
     } else {
         hsFileStream S(PlasmaVer::pvUnknown);
-        if (!S.open(filename.toUtf8().data(), fmRead)) return false;
+        if (!S.open(filename.toUtf8().data(), fmRead))
+            return false;
         fEncryption = kEncNone;
         fEncoding = DetectEncoding(&S);
         fEditor->setText(LoadData(&S, fEncoding));
@@ -518,7 +520,8 @@ bool QPlasmaTextDoc::saveTo(QString filename)
         } else if (fEncryption == kEncXtea) {
             type = plEncryptedStream::kEncXtea;
         }
-        if (!S.open(filename.toUtf8().data(), fmCreate, type)) return false;
+        if (!S.open(filename.toUtf8().data(), fmCreate, type))
+            return false;
         WriteEncoding(&S, fEncoding);
         SaveData(&S, fEncoding, fEditor->text());
     }

--- a/src/PrpShop/CMakeLists.txt
+++ b/src/PrpShop/CMakeLists.txt
@@ -1,9 +1,5 @@
-set(PrpShop_MOC_Headers
+set(PrpShop_Headers
     Main.h
-    ../QColorEdit.h
-    ../QLinkLabel.h
-    ../QNumerics.h
-    ../QHexWidget.h
     QKeyDialog.h
     QPrcEditor.h
     QHexViewer.h
@@ -69,10 +65,6 @@ set(PrpShop_MOC_Headers
 
 set(PrpShop_Sources
     Main.cpp
-    ../QColorEdit.cpp
-    ../QLinkLabel.cpp
-    ../QNumerics.cpp
-    ../QHexWidget.cpp
     QKeyDialog.cpp
     QPlasmaUtils.cpp
     QPlasmaTreeItem.cpp
@@ -139,30 +131,17 @@ set(PrpShop_Sources
     PRP/Render/QTrackball.cpp
 )
 
-if(NOT WIN32 AND NOT APPLE)
-    set(PrpShop_Sources "${PrpShop_Sources}"
-        ../3rdParty/qticonloader.cpp
-    )
-endif()
-
 if(WIN32)
     set(PrpShop_Sources ${PrpShop_Sources} res/PrpShop.rc)
 endif()
 
-if(PS_USE_QT5)
-    find_package(Qt5Widgets REQUIRED)
-    find_package(Qt5OpenGL REQUIRED)
-endif()
+find_package(Qt5OpenGL REQUIRED)
 
 # generate rules for building source files from the resources
-qtx_add_resources(PrpShop_RCC images.qrc)
-# generate rules for building source files that moc generates
-qtx_wrap_cpp(PrpShop_MOC "${PrpShop_MOC_Headers}")
+qt5_add_resources(PrpShop_RCC images.qrc)
 
-include_directories("${PROJECT_SOURCE_DIR}/src/3rdParty")
 include_directories("${PROJECT_SOURCE_DIR}/QScintilla/Qt4Qt5")
 include_directories("${PROJECT_SOURCE_DIR}/src/PrpShop")
-include_directories("${HSPlasma_INCLUDE_DIRS}")
 
 # QtOpenGL dependencies (maybe the Qt OpenGL cmake stuff is broken, but I had
 # to copy this here from Qt4ConfigDependentSettings.cmake)
@@ -170,15 +149,13 @@ find_package(OpenGL)
 set(QT_QTOPENGL_LIB_DEPENDENCIES ${OPENGL_glu_LIBRARY} ${OPENGL_gl_LIBRARY})
 
 add_executable(PrpShop WIN32 MACOSX_BUNDLE
-               ${PrpShop_Sources} ${PrpShop_MOC} ${PrpShop_RCC})
-if(PS_USE_QT5)
-    target_link_libraries(PrpShop Qt5::Widgets Qt5::OpenGL)
-elseif(PS_USE_QT4)
-    target_link_libraries(PrpShop ${QT_QTMAIN_LIBRARY} ${QT_QTCORE_LIBRARY}
-                                  ${QT_QTGUI_LIBRARY} ${QT_QTOPENGL_LIBRARY})
-endif()
+               ${PrpShop_Sources} ${PrpShop_Headers} ${PrpShop_RCC})
+target_link_libraries(PrpShop PSCommon Qt5::Widgets Qt5::OpenGL)
 target_link_libraries(PrpShop qscintilla2-ps3 HSPlasma)
 target_link_libraries(PrpShop ${QT_QTOPENGL_LIB_DEPENDENCIES})
+if(NOT WIN32 AND NOT APPLE)
+    target_link_libraries(PrpShop PSIconLoader)
+endif()
 
 if(APPLE)
     set(MACOSX_BUNDLE true)

--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -36,7 +36,7 @@
 #include <PRP/Surface/plMipmap.h>
 
 #include "Main.h"
-#include "../QPlasma.h"
+#include "QPlasma.h"
 #include "QPlasmaUtils.h"
 #include "QKeyDialog.h"
 #include "PRP/QCreatable.h"

--- a/src/PrpShop/PRP/Animation/QAnimTimeConvert.cpp
+++ b/src/PrpShop/PRP/Animation/QAnimTimeConvert.cpp
@@ -21,7 +21,7 @@
 #include <QTabWidget>
 #include <QGridLayout>
 #include <QMenu>
-#include "../../Main.h"
+#include "Main.h"
 #include <ResManager/plFactory.h>
 
 /* QATCCurveLink */

--- a/src/PrpShop/PRP/Animation/QAnimTimeConvert.h
+++ b/src/PrpShop/PRP/Animation/QAnimTimeConvert.h
@@ -17,13 +17,13 @@
 #ifndef _QANIMTIMECONVERT_H
 #define _QANIMTIMECONVERT_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Animation/plAnimTimeConvert.h>
 #include <QLineEdit>
 #include <QCheckBox>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QATCCurveLink : public QCreatableLink {
     Q_OBJECT

--- a/src/PrpShop/PRP/Audio/QAudible.cpp
+++ b/src/PrpShop/PRP/Audio/QAudible.cpp
@@ -18,8 +18,8 @@
 
 #include <QGridLayout>
 #include <PRP/Audio/plAudible.h>
-#include "../../QKeyDialog.h"
-#include "../../Main.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 /* QAudible */
 QAudible::QAudible(plCreatable* pCre, QWidget* parent)

--- a/src/PrpShop/PRP/Audio/QAudible.h
+++ b/src/PrpShop/PRP/Audio/QAudible.h
@@ -17,9 +17,9 @@
 #ifndef _QAUDIBLE_H
 #define _QAUDIBLE_H
 
-#include "../QCreatable.h"
-#include "../QKeyList.h"
-#include "../QObjLink.h"
+#include "PRP/QCreatable.h"
+#include "PRP/QKeyList.h"
+#include "PRP/QObjLink.h"
 
 class QAudible : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Audio/QSoundBuffer.cpp
+++ b/src/PrpShop/PRP/Audio/QSoundBuffer.cpp
@@ -19,7 +19,7 @@
 #include <QLabel>
 #include <QGroupBox>
 #include <QGridLayout>
-#include "../../../QPlasma.h"
+#include "QPlasma.h"
 
 QSoundBuffer::QSoundBuffer(plCreatable* pCre, QWidget* parent)
             : QCreatable(pCre, kSoundBuffer, parent)

--- a/src/PrpShop/PRP/Audio/QSoundBuffer.h
+++ b/src/PrpShop/PRP/Audio/QSoundBuffer.h
@@ -17,7 +17,7 @@
 #ifndef _QSOUNDBUFFER_H
 #define _QSOUNDBUFFER_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <QCheckBox>
 #include <QComboBox>

--- a/src/PrpShop/PRP/Audio/QWinSound.cpp
+++ b/src/PrpShop/PRP/Audio/QWinSound.cpp
@@ -20,8 +20,8 @@
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <PRP/Audio/plWin32StaticSound.h>
-#include "../../QKeyDialog.h"
-#include "../../Main.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 /* QEaxSourceSettings */
 QEaxSourceSettings::QEaxSourceSettings(plEAXSourceSettings* eax, QWidget* parent)

--- a/src/PrpShop/PRP/Audio/QWinSound.h
+++ b/src/PrpShop/PRP/Audio/QWinSound.h
@@ -17,12 +17,12 @@
 #ifndef _QWINSOUND_H
 #define _QWINSOUND_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Audio/plEAXEffects.h>
 #include <QComboBox>
 #include <QCheckBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QEaxSourceSettings : public QWidget {
     Q_OBJECT

--- a/src/PrpShop/PRP/Avatar/QAvLadderMod.h
+++ b/src/PrpShop/PRP/Avatar/QAvLadderMod.h
@@ -17,13 +17,13 @@
 #ifndef _QAVLADDERMOD_H
 #define _QAVLADDERMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Avatar/plLadderModifier.h>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QButtonGroup>
-#include "../QVector3.h"
+#include "PRP/QVector3.h"
 
 class QAvLadderMod : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Avatar/QMultistageBehMod.cpp
+++ b/src/PrpShop/PRP/Avatar/QMultistageBehMod.cpp
@@ -21,7 +21,7 @@
 #include <QGroupBox>
 #include <QGridLayout>
 #include <QMenu>
-#include "../../Main.h"
+#include "Main.h"
 
 /* QAnimStage */
 static QString s_PlayTypes[] = { "None", "Key", "Auto" };

--- a/src/PrpShop/PRP/Avatar/QMultistageBehMod.h
+++ b/src/PrpShop/PRP/Avatar/QMultistageBehMod.h
@@ -17,14 +17,14 @@
 #ifndef _QMULTISTAGEBEHMOD_H
 #define _QMULTISTAGEBEHMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Avatar/plMultistageBehMod.h>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLineEdit>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QAnimStage : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIButtonMod.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIButtonMod.cpp
@@ -18,8 +18,8 @@
 
 #include <QTabWidget>
 #include <QGridLayout>
-#include "../../Main.h"
-#include "../../QKeyDialog.h"
+#include "Main.h"
+#include "QKeyDialog.h"
 
 /* QGUIButtonMod */
 QGUIButtonMod::QGUIButtonMod(plCreatable* pCre, QWidget* parent)

--- a/src/PrpShop/PRP/GUI/QGUIButtonMod.h
+++ b/src/PrpShop/PRP/GUI/QGUIButtonMod.h
@@ -17,12 +17,12 @@
 #ifndef _QGUIBUTTONMOD_H
 #define _QGUIBUTTONMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIButtonMod.h>
 #include <QComboBox>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QGUIButtonMod : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUICheckBoxCtrl.h
+++ b/src/PrpShop/PRP/GUI/QGUICheckBoxCtrl.h
@@ -17,12 +17,12 @@
 #ifndef _QGUICHECKBOXCTRL_H
 #define _QGUICHECKBOXCTRL_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUICheckBoxCtrl.h>
 #include <QCheckBox>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QGUICheckBoxCtrl : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIClickMapCtrl.h
+++ b/src/PrpShop/PRP/GUI/QGUIClickMapCtrl.h
@@ -17,11 +17,11 @@
 #ifndef _QGUICLICKMAPCTRL_H
 #define _QGUICLICKMAPCTRL_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIMisc.hpp>
 #include <QCheckBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QGUIClickMapCtrl : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIControlMod.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIControlMod.cpp
@@ -18,8 +18,8 @@
 
 #include <QTabWidget>
 #include <QGridLayout>
-#include "../../Main.h"
-#include "../../QKeyDialog.h"
+#include "Main.h"
+#include "QKeyDialog.h"
 
 /* QGUIColorScheme */
 QGUIColorScheme::QGUIColorScheme(QWidget* parent)

--- a/src/PrpShop/PRP/GUI/QGUIControlMod.h
+++ b/src/PrpShop/PRP/GUI/QGUIControlMod.h
@@ -17,15 +17,15 @@
 #ifndef _QGUICONTROLMOD_H
 #define _QGUICONTROLMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIControlMod.h>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QGroupBox>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
-#include "../QColorEdit.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
+#include "QColorEdit.h"
 
 class QGUIColorScheme : public QWidget {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIDialogMod.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIDialogMod.cpp
@@ -18,8 +18,8 @@
 
 #include <QGroupBox>
 #include <QGridLayout>
-#include "../../Main.h"
-#include "../../QKeyDialog.h"
+#include "Main.h"
+#include "QKeyDialog.h"
 
 /* QGUIDialogMod */
 QGUIDialogMod::QGUIDialogMod(plCreatable* pCre, QWidget* parent)

--- a/src/PrpShop/PRP/GUI/QGUIDialogMod.h
+++ b/src/PrpShop/PRP/GUI/QGUIDialogMod.h
@@ -17,13 +17,13 @@
 #ifndef _QGUIDIALOGMOD_H
 #define _QGUIDIALOGMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIDialogMod.h>
 #include <QCheckBox>
 #include "QGUIControlMod.h"
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QGUIDialogMod : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIDraggableMod.h
+++ b/src/PrpShop/PRP/GUI/QGUIDraggableMod.h
@@ -17,11 +17,11 @@
 #ifndef _QGUIDRAGGABLEMOD_H
 #define _QGUIDRAGGABLEMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIMisc.hpp>
 #include <QCheckBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QGUIDraggableMod : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIDynDisplayCtrl.h
+++ b/src/PrpShop/PRP/GUI/QGUIDynDisplayCtrl.h
@@ -17,11 +17,11 @@
 #ifndef _QGUIDYNDISPLAYCTRL_H
 #define _QGUIDYNDISPLAYCTRL_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIDynDisplayCtrl.h>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QGUIDynDisplayCtrl : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIKnobCtrl.h
+++ b/src/PrpShop/PRP/GUI/QGUIKnobCtrl.h
@@ -17,12 +17,12 @@
 #ifndef _QGUIKNOBCTRL_H
 #define _QGUIKNOBCTRL_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIKnobCtrl.h>
 #include <QCheckBox>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QGUIKnobCtrl : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIListBoxMod.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIListBoxMod.cpp
@@ -18,8 +18,8 @@
 
 #include <QGroupBox>
 #include <QGridLayout>
-#include "../../Main.h"
-#include "../../QKeyDialog.h"
+#include "Main.h"
+#include "QKeyDialog.h"
 
 /* QGUIListBoxMod */
 QGUIListBoxMod::QGUIListBoxMod(plCreatable* pCre, QWidget* parent)

--- a/src/PrpShop/PRP/GUI/QGUIListBoxMod.h
+++ b/src/PrpShop/PRP/GUI/QGUIListBoxMod.h
@@ -17,11 +17,11 @@
 #ifndef _QGUILISTBOXMOD_H
 #define _QGUILISTBOXMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIListBoxMod.h>
 #include <QCheckBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QGUIListBoxMod : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIMenuItem.h
+++ b/src/PrpShop/PRP/GUI/QGUIMenuItem.h
@@ -17,11 +17,11 @@
 #ifndef _QGUIMENUITEM_H
 #define _QGUIMENUITEM_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIButtonMod.h>
 #include <QCheckBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QGUIMenuItem : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIMultiLineEditCtrl.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIMultiLineEditCtrl.cpp
@@ -17,8 +17,8 @@
 #include "QGUIMultiLineEditCtrl.h"
 
 #include <QGridLayout>
-#include "../../Main.h"
-#include "../../QKeyDialog.h"
+#include "Main.h"
+#include "QKeyDialog.h"
 
 /* QGUIMultiLineEditCtrl */
 QGUIMultiLineEditCtrl::QGUIMultiLineEditCtrl(plCreatable* pCre, QWidget* parent)

--- a/src/PrpShop/PRP/GUI/QGUIMultiLineEditCtrl.h
+++ b/src/PrpShop/PRP/GUI/QGUIMultiLineEditCtrl.h
@@ -17,10 +17,10 @@
 #ifndef _QGUIMULTILINEEDITCTRL_H
 #define _QGUIMULTILINEEDITCTRL_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIMultiLineEditCtrl.h>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QGUIMultiLineEditCtrl : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIPopUpMenu.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIPopUpMenu.cpp
@@ -19,8 +19,8 @@
 #include <QGroupBox>
 #include <QGridLayout>
 #include <QMenu>
-#include "../../Main.h"
-#include "../../QKeyDialog.h"
+#include "Main.h"
+#include "QKeyDialog.h"
 
 /* QPopupMenuItemList */
 QPopupMenuItemList::QPopupMenuItemList(QWidget* parent)

--- a/src/PrpShop/PRP/GUI/QGUIPopUpMenu.h
+++ b/src/PrpShop/PRP/GUI/QGUIPopUpMenu.h
@@ -17,14 +17,14 @@
 #ifndef _QGUIPOPUPMENU_H
 #define _QGUIPOPUPMENU_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIPopUpMenu.h>
 #include <QCheckBox>
 #include <QTreeWidget>
 #include <QComboBox>
 #include <QDialog>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QPopupMenuItemList : public QTreeWidget {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIProgressCtrl.h
+++ b/src/PrpShop/PRP/GUI/QGUIProgressCtrl.h
@@ -17,12 +17,12 @@
 #ifndef _QGUIPROGRESSCTRL_H
 #define _QGUIPROGRESSCTRL_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIProgressCtrl.h>
 #include <QCheckBox>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QGUIProgressCtrl : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIRadioGroupCtrl.h
+++ b/src/PrpShop/PRP/GUI/QGUIRadioGroupCtrl.h
@@ -17,13 +17,13 @@
 #ifndef _QGUIRADIOGROUPCTRL_H
 #define _QGUIRADIOGROUPCTRL_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIRadioGroupCtrl.h>
 #include <QCheckBox>
 #include <QComboBox>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QGUIRadioGroupCtrl : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUISkin.cpp
+++ b/src/PrpShop/PRP/GUI/QGUISkin.cpp
@@ -18,8 +18,8 @@
 
 #include <QGroupBox>
 #include <QGridLayout>
-#include "../../Main.h"
-#include "../../QKeyDialog.h"
+#include "Main.h"
+#include "QKeyDialog.h"
 
 /* QGUISkin */
 QGUISkin::QGUISkin(plCreatable* pCre, QWidget* parent)

--- a/src/PrpShop/PRP/GUI/QGUISkin.h
+++ b/src/PrpShop/PRP/GUI/QGUISkin.h
@@ -17,11 +17,11 @@
 #ifndef _QGUISKIN_H
 #define _QGUISKIN_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUISkin.h>
 #include <QComboBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QGUISkin : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUITextBoxMod.h
+++ b/src/PrpShop/PRP/GUI/QGUITextBoxMod.h
@@ -17,12 +17,12 @@
 #ifndef _QGUITEXTBOXMOD_H
 #define _QGUITEXTBOXMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUITextBoxMod.h>
 #include <QCheckBox>
 #include <QTextEdit>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QGUITextBoxMod : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QGUIUpDownPairMod.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIUpDownPairMod.cpp
@@ -17,8 +17,8 @@
 #include "QGUIUpDownPairMod.h"
 
 #include <QGridLayout>
-#include "../../Main.h"
-#include "../../QKeyDialog.h"
+#include "Main.h"
+#include "QKeyDialog.h"
 
 /* QGUIUpDownPairMod */
 QGUIUpDownPairMod::QGUIUpDownPairMod(plCreatable* pCre, QWidget* parent)

--- a/src/PrpShop/PRP/GUI/QGUIUpDownPairMod.h
+++ b/src/PrpShop/PRP/GUI/QGUIUpDownPairMod.h
@@ -17,10 +17,10 @@
 #ifndef _QGUIUPDOWNPAIRMOD_H
 #define _QGUIUPDOWNPAIRMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/pfGUIUpDownPairMod.h>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QGUIUpDownPairMod : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/GUI/QImageLibMod.h
+++ b/src/PrpShop/PRP/GUI/QImageLibMod.h
@@ -17,11 +17,11 @@
 #ifndef _QIMAGELIBMOD_H
 #define _QIMAGELIBMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/GUI/plImageLibMod.h>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QImageLibMod : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Light/QShadowMaster.cpp
+++ b/src/PrpShop/PRP/Light/QShadowMaster.cpp
@@ -20,8 +20,8 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QGridLayout>
-#include "../../QKeyDialog.h"
-#include "../../Main.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 QShadowMaster::QShadowMaster(plCreatable* pCre, QWidget* parent)
              : QCreatable(pCre, pCre->ClassIndex(), parent)

--- a/src/PrpShop/PRP/Light/QShadowMaster.h
+++ b/src/PrpShop/PRP/Light/QShadowMaster.h
@@ -17,11 +17,11 @@
 #ifndef _QSHADOWMASTER_H
 #define _QSHADOWMASTER_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Light/plShadowMaster.h>
 #include <QCheckBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QShadowMaster : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Message/QMsgForwarder.h
+++ b/src/PrpShop/PRP/Message/QMsgForwarder.h
@@ -17,10 +17,10 @@
 #ifndef _QMSGFORWARDER_H
 #define _QMSGFORWARDER_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Message/plMsgForwarder.h>
-#include "../QKeyList.h"
+#include "PRP/QKeyList.h"
 
 class QMsgForwarder : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Modifier/QInterfaceInfoModifier.h
+++ b/src/PrpShop/PRP/Modifier/QInterfaceInfoModifier.h
@@ -17,11 +17,11 @@
 #ifndef _QINTERFACEINFOMODIFIER_H
 #define _QINTERFACEINFOMODIFIER_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Modifier/plInterfaceInfoModifier.h>
-#include "../QKeyList.h"
-#include "../QObjLink.h"
+#include "PRP/QKeyList.h"
+#include "PRP/QObjLink.h"
 
 class QInterfaceInfoModifier : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Modifier/QMaintainersMarkerModifier.h
+++ b/src/PrpShop/PRP/Modifier/QMaintainersMarkerModifier.h
@@ -18,8 +18,8 @@
 #define _QMAINTAINERSMARKERMODIFIER_H
 
 #include <QComboBox>
-#include "../QCreatable.h"
-#include "../QObjLink.h"
+#include "PRP/QCreatable.h"
+#include "PRP/QObjLink.h"
 
 class QMaintainersMarkerModifier : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Modifier/QOneShotMod.cpp
+++ b/src/PrpShop/PRP/Modifier/QOneShotMod.cpp
@@ -19,7 +19,7 @@
 #include <QLabel>
 #include <QGroupBox>
 #include <QGridLayout>
-#include "../../../QPlasma.h"
+#include "QPlasma.h"
 
 QOneShotMod::QOneShotMod(plCreatable* pCre, QWidget* parent)
            : QCreatable(pCre, kOneShotMod, parent)

--- a/src/PrpShop/PRP/Modifier/QOneShotMod.h
+++ b/src/PrpShop/PRP/Modifier/QOneShotMod.h
@@ -17,12 +17,12 @@
 #ifndef _QONESHOTMOD_H
 #define _QONESHOTMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Modifier/plOneShotMod.h>
 #include <QLineEdit>
 #include <QCheckBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QOneShotMod : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Modifier/QPythonFileMod.cpp
+++ b/src/PrpShop/PRP/Modifier/QPythonFileMod.cpp
@@ -20,8 +20,8 @@
 #include <QContextMenuEvent>
 #include <QDialogButtonBox>
 #include <QGridLayout>
-#include "../../Main.h"
-#include "../../QKeyDialog.h"
+#include "Main.h"
+#include "QKeyDialog.h"
 
 static const QString s_PythonParamTypes[] = {
     "(Invalid)", "Integer", "Float", "Boolean", "String", "Scene Object",

--- a/src/PrpShop/PRP/Modifier/QPythonFileMod.h
+++ b/src/PrpShop/PRP/Modifier/QPythonFileMod.h
@@ -17,15 +17,15 @@
 #ifndef _QPYTHONFILEMOD_H
 #define _QPYTHONFILEMOD_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Modifier/plPythonFileMod.h>
 #include <QDialog>
 #include <QComboBox>
 #include <QSpinBox>
 #include <QLabel>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QPythonParamList : public QTreeWidget {
     Q_OBJECT

--- a/src/PrpShop/PRP/Modifier/QSpawnModifier.h
+++ b/src/PrpShop/PRP/Modifier/QSpawnModifier.h
@@ -17,8 +17,8 @@
 #ifndef _QSPAWNMODIFIER_H
 #define _QSPAWNMODIFIER_H
 
-#include "../QCreatable.h"
-#include "../QObjLink.h"
+#include "PRP/QCreatable.h"
+#include "PRP/QObjLink.h"
 
 class QSpawnModifier : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Object/QAudioInterface.cpp
+++ b/src/PrpShop/PRP/Object/QAudioInterface.cpp
@@ -19,8 +19,8 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QGridLayout>
-#include "../../QKeyDialog.h"
-#include "../../Main.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 QAudioInterface::QAudioInterface(plCreatable* pCre, QWidget* parent)
                : QCreatable(pCre, kAudioInterface, parent)

--- a/src/PrpShop/PRP/Object/QAudioInterface.h
+++ b/src/PrpShop/PRP/Object/QAudioInterface.h
@@ -17,11 +17,11 @@
 #ifndef _QAUDIOINTERFACE_H
 #define _QAUDIOINTERFACE_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Object/plAudioInterface.h>
 #include <QCheckBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QAudioInterface : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Object/QCoordinateInterface.cpp
+++ b/src/PrpShop/PRP/Object/QCoordinateInterface.cpp
@@ -20,8 +20,8 @@
 #include <QLabel>
 #include <QTabWidget>
 #include <QGridLayout>
-#include "../../QKeyDialog.h"
-#include "../../Main.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 QCoordinateInterface::QCoordinateInterface(plCreatable* pCre, QWidget* parent)
                     : QCreatable(pCre, kCoordinateInterface, parent)

--- a/src/PrpShop/PRP/Object/QCoordinateInterface.h
+++ b/src/PrpShop/PRP/Object/QCoordinateInterface.h
@@ -17,13 +17,13 @@
 #ifndef _QCOORDINATEINTERFACE_H
 #define _QCOORDINATEINTERFACE_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Object/plCoordinateInterface.h>
 #include <QCheckBox>
-#include "../QKeyList.h"
-#include "../QMatrix44.h"
-#include "../QObjLink.h"
+#include "PRP/QKeyList.h"
+#include "PRP/QMatrix44.h"
+#include "PRP/QObjLink.h"
 
 class QCoordinateInterface : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Object/QDrawInterface.cpp
+++ b/src/PrpShop/PRP/Object/QDrawInterface.cpp
@@ -22,8 +22,8 @@
 #include <QGridLayout>
 #include <QMenu>
 #include <QDialogButtonBox>
-#include "../../QKeyDialog.h"
-#include "../../Main.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 /* QDrawableList */
 QDrawableList::QDrawableList(plKey container, QWidget* parent)

--- a/src/PrpShop/PRP/Object/QDrawInterface.h
+++ b/src/PrpShop/PRP/Object/QDrawInterface.h
@@ -17,15 +17,15 @@
 #ifndef _QDRAWINTERFACE_H
 #define _QDRAWINTERFACE_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Object/plDrawInterface.h>
 #include <QCheckBox>
 #include <QSpinBox>
 #include <QComboBox>
 #include <QDialog>
-#include "../QKeyList.h"
-#include "../QObjLink.h"
+#include "PRP/QKeyList.h"
+#include "PRP/QObjLink.h"
 
 class QDrawableList : public QKeyList {
     Q_OBJECT

--- a/src/PrpShop/PRP/Object/QSceneObject.cpp
+++ b/src/PrpShop/PRP/Object/QSceneObject.cpp
@@ -19,9 +19,9 @@
 #include <QGroupBox>
 #include <QTabWidget>
 #include <QGridLayout>
-#include "../../QPlasmaUtils.h"
-#include "../../QKeyDialog.h"
-#include "../../Main.h"
+#include "QPlasmaUtils.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 QSceneObject::QSceneObject(plCreatable* pCre, QWidget* parent)
             : QCreatable(pCre, kSceneObject, parent)

--- a/src/PrpShop/PRP/Object/QSceneObject.h
+++ b/src/PrpShop/PRP/Object/QSceneObject.h
@@ -17,11 +17,11 @@
 #ifndef _QSCENEOBJECT_H
 #define _QSCENEOBJECT_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Object/plSceneObject.h>
-#include "../QKeyList.h"
-#include "../QObjLink.h"
+#include "PRP/QKeyList.h"
+#include "PRP/QObjLink.h"
 
 class QSceneObject : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Object/QSimulationInterface.cpp
+++ b/src/PrpShop/PRP/Object/QSimulationInterface.cpp
@@ -19,8 +19,8 @@
 #include <QGroupBox>
 #include <QLabel>
 #include <QGridLayout>
-#include "../../QKeyDialog.h"
-#include "../../Main.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 QSimulationInterface::QSimulationInterface(plCreatable* pCre, QWidget* parent)
                     : QCreatable(pCre, kSimulationInterface, parent)

--- a/src/PrpShop/PRP/Object/QSimulationInterface.h
+++ b/src/PrpShop/PRP/Object/QSimulationInterface.h
@@ -17,11 +17,11 @@
 #ifndef _QSIMULATIONINTERFACE_H
 #define _QSIMULATIONINTERFACE_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Object/plSimulationInterface.h>
 #include <QCheckBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QSimulationInterface : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Object/QSynchedObject.cpp
+++ b/src/PrpShop/PRP/Object/QSynchedObject.cpp
@@ -20,7 +20,7 @@
 #include <QLabel>
 #include <QGridLayout>
 #include <QTabWidget>
-#include "../../../QPlasma.h"
+#include "QPlasma.h"
 
 QSynchedObject::QSynchedObject(plCreatable* pCre, QWidget* parent)
               : QCreatable(pCre, kSynchedObject, parent)

--- a/src/PrpShop/PRP/Object/QSynchedObject.h
+++ b/src/PrpShop/PRP/Object/QSynchedObject.h
@@ -17,11 +17,11 @@
 #ifndef _QSYNCHEDOBJECT_H
 #define _QSYNCHEDOBJECT_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Object/plCoordinateInterface.h>
 #include <QCheckBox>
-#include "../QKeyList.h"
+#include "PRP/QKeyList.h"
 
 class QSynchedObject : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Physics/QCollisionDetector.cpp
+++ b/src/PrpShop/PRP/Physics/QCollisionDetector.cpp
@@ -19,8 +19,8 @@
 #include <QLabel>
 #include <QGroupBox>
 #include <QGridLayout>
-#include "../../QKeyDialog.h"
-#include "../../Main.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 QCollisionDetector::QCollisionDetector(plCreatable* pCre, QWidget* parent)
                   : QCreatable(pCre, pCre->ClassIndex(), parent)

--- a/src/PrpShop/PRP/Physics/QCollisionDetector.h
+++ b/src/PrpShop/PRP/Physics/QCollisionDetector.h
@@ -17,11 +17,11 @@
 #ifndef _QCOLLISIONDETECTOR_H
 #define _QCOLLISIONDETECTOR_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Physics/plCollisionDetector.h>
 #include <QCheckBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QCollisionDetector : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Physics/QDetectorModifier.cpp
+++ b/src/PrpShop/PRP/Physics/QDetectorModifier.cpp
@@ -18,8 +18,8 @@
 
 #include <QLabel>
 #include <QGridLayout>
-#include "../../QKeyDialog.h"
-#include "../../Main.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 QDetectorModifier::QDetectorModifier(plCreatable* pCre, QWidget* parent)
                  : QCreatable(pCre, pCre->ClassIndex(), parent)

--- a/src/PrpShop/PRP/Physics/QDetectorModifier.h
+++ b/src/PrpShop/PRP/Physics/QDetectorModifier.h
@@ -17,11 +17,11 @@
 #ifndef _QDETECTORMODIFIER_H
 #define _QDETECTORMODIFIER_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Physics/plDetectorModifier.h>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QDetectorModifier : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/QCreatable.cpp
+++ b/src/PrpShop/PRP/QCreatable.cpp
@@ -18,7 +18,7 @@
 
 #include <PRP/KeyedObject/hsKeyedObject.h>
 #include <QMessageBox>
-#include "../QPlasmaUtils.h"
+#include "QPlasmaUtils.h"
 
 QCreatable::QCreatable(plCreatable* pCre, int type, QWidget* parent)
           : QWidget(parent), fCreatable(pCre), fForceType(type)

--- a/src/PrpShop/PRP/QCreatable.h
+++ b/src/PrpShop/PRP/QCreatable.h
@@ -19,7 +19,7 @@
 
 #include <QWidget>
 #include <ResManager/plResManager.h>
-#include "../QPlasmaUtils.h"
+#include "QPlasmaUtils.h"
 
 class QCreatable : public QWidget {
     Q_OBJECT

--- a/src/PrpShop/PRP/QKeyList.cpp
+++ b/src/PrpShop/PRP/QKeyList.cpp
@@ -19,9 +19,9 @@
 #include <QContextMenuEvent>
 #include <QMenu>
 #include <QInputDialog>
-#include "../QPlasmaUtils.h"
-#include "../QKeyDialog.h"
-#include "../Main.h"
+#include "QPlasmaUtils.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 /* QKeyList */
 QKeyList::QKeyList(plKey container, QWidget* parent)

--- a/src/PrpShop/PRP/QMatrix44.h
+++ b/src/PrpShop/PRP/QMatrix44.h
@@ -19,7 +19,7 @@
 
 #include <QWidget>
 #include <Math/hsMatrix44.h>
-#include "../../QNumerics.h"
+#include "QNumerics.h"
 
 class QMatrix44 : public QWidget {
     Q_OBJECT

--- a/src/PrpShop/PRP/QObjLink.cpp
+++ b/src/PrpShop/PRP/QObjLink.cpp
@@ -19,7 +19,7 @@
 #include <QHBoxLayout>
 #include <QMouseEvent>
 #include <QMenu>
-#include "../Main.h"
+#include "Main.h"
 
 /* QCreatableLink */
 QCreatableLink::QCreatableLink(QWidget* parent, bool canEdit)

--- a/src/PrpShop/PRP/QObjLink.h
+++ b/src/PrpShop/PRP/QObjLink.h
@@ -18,7 +18,7 @@
 #define _QOBJLINK_H
 
 #include <PRP/KeyedObject/hsKeyedObject.h>
-#include "../../QLinkLabel.h"
+#include "QLinkLabel.h"
 
 class QCreatableLink : public QWidget {
     Q_OBJECT

--- a/src/PrpShop/PRP/QVector3.h
+++ b/src/PrpShop/PRP/QVector3.h
@@ -19,7 +19,7 @@
 
 #include <QWidget>
 #include <Math/hsGeometry3.h>
-#include "../../QNumerics.h"
+#include "QNumerics.h"
 
 class QVector3 : public QWidget {
     Q_OBJECT

--- a/src/PrpShop/PRP/Render/QPlasmaRender.cpp
+++ b/src/PrpShop/PRP/Render/QPlasmaRender.cpp
@@ -152,7 +152,7 @@ void QPlasmaRender::initializeGL()
     for (it = fLayers.begin(); it != fLayers.end(); it++)
         compileTexture((*it).first, (*it).second.fTexNameId);
 
-    buildNewMode((DrawMode)fDrawMode);
+    buildNewMode(fDrawMode);
 }
 
 void QPlasmaRender::resizeGL(int width, int height)
@@ -181,7 +181,7 @@ void QPlasmaRender::paintGL()
     }
 
     for (auto it = fObjects.begin(); it != fObjects.end(); it++)
-        glCallList(it->second.getList((DrawMode)fDrawMode));
+        glCallList(it->second.getList(fDrawMode));
 }
 
 void QPlasmaRender::mouseMoveEvent(QMouseEvent* evt)
@@ -358,8 +358,8 @@ void QPlasmaRender::build(NavigationMode navMode, DrawMode drawMode)
 void QPlasmaRender::rebuild()
 {
     for (auto it = fObjects.begin(); it != fObjects.end(); it++) {
-        glNewList(it->second.getList((DrawMode)fDrawMode), GL_COMPILE);
-        compileObject(it->first, (DrawMode)fDrawMode);
+        glNewList(it->second.getList(fDrawMode), GL_COMPILE);
+        compileObject(it->first, fDrawMode);
         glEndList();
     }
 }
@@ -382,8 +382,8 @@ void QPlasmaRender::rebuildObject(plKey obj)
 {
     auto found = fObjects.find(obj);
     if (found != fObjects.end()) {
-        glNewList(found->second.getList((DrawMode)fDrawMode), GL_COMPILE);
-        compileObject(found->first, (DrawMode)fDrawMode);
+        glNewList(found->second.getList(fDrawMode), GL_COMPILE);
+        compileObject(found->first, fDrawMode);
         glEndList();
     }
 }

--- a/src/PrpShop/PRP/Render/QPlasmaRender.cpp
+++ b/src/PrpShop/PRP/Render/QPlasmaRender.cpp
@@ -30,7 +30,7 @@
 #include <QMessageBox>
 #include <QMouseEvent>
 #include <cmath>
-#include "../../QPlasmaUtils.h"
+#include "QPlasmaUtils.h"
 
 PFNGLCOMPRESSEDTEXIMAGE2DARBPROC glCompressedTexImage2DARB = NULL;
 

--- a/src/PrpShop/PRP/Render/QSceneObj_Preview.h
+++ b/src/PrpShop/PRP/Render/QSceneObj_Preview.h
@@ -17,7 +17,7 @@
 #ifndef _QSCENEOBJ_PREVIEW_H
 #define _QSCENEOBJ_PREVIEW_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 #include "QPlasmaRender.h"
 
 class QSceneObj_Preview : public QCreatable {

--- a/src/PrpShop/PRP/Surface/QCubicEnvironmap.cpp
+++ b/src/PrpShop/PRP/Surface/QCubicEnvironmap.cpp
@@ -19,7 +19,7 @@
 #include <QLabel>
 #include <QGroupBox>
 #include <QGridLayout>
-#include "../../QPlasmaUtils.h"
+#include "QPlasmaUtils.h"
 
 /* QCubicEnvironmap */
 QCubicEnvironmap::QCubicEnvironmap(plCreatable* pCre, QWidget* parent)

--- a/src/PrpShop/PRP/Surface/QDynamicTextMap.cpp
+++ b/src/PrpShop/PRP/Surface/QDynamicTextMap.cpp
@@ -19,7 +19,7 @@
 #include <QLabel>
 #include <QGroupBox>
 #include <QGridLayout>
-#include "../../QPlasmaUtils.h"
+#include "QPlasmaUtils.h"
 
 /* QDynamicTextMap */
 QDynamicTextMap::QDynamicTextMap(plCreatable* pCre, QWidget* parent)

--- a/src/PrpShop/PRP/Surface/QFadeOpacityMod.cpp
+++ b/src/PrpShop/PRP/Surface/QFadeOpacityMod.cpp
@@ -19,7 +19,7 @@
 #include <QLabel>
 #include <QGroupBox>
 #include <QGridLayout>
-#include "../../QPlasmaUtils.h"
+#include "QPlasmaUtils.h"
 
 /* QFadeOpacityMod */
 QFadeOpacityMod::QFadeOpacityMod(plCreatable* pCre, QWidget* parent)

--- a/src/PrpShop/PRP/Surface/QFadeOpacityMod.h
+++ b/src/PrpShop/PRP/Surface/QFadeOpacityMod.h
@@ -17,8 +17,8 @@
 #ifndef _QFADEOPACITYMOD_H
 #define _QFADEOPACITYMOD_H
 
-#include "../QCreatable.h"
-#include "../QObjLink.h"
+#include "PRP/QCreatable.h"
+#include "PRP/QObjLink.h"
 #include <QImage>
 #include <QCheckBox>
 #include <QSpinBox>

--- a/src/PrpShop/PRP/Surface/QLayer.cpp
+++ b/src/PrpShop/PRP/Surface/QLayer.cpp
@@ -21,8 +21,8 @@
 #include <QTabWidget>
 #include <QGridLayout>
 #include <QSpacerItem>
-#include "../../QKeyDialog.h"
-#include "../../Main.h"
+#include "QKeyDialog.h"
+#include "Main.h"
 
 QLayer::QLayer(plCreatable* pCre, QWidget* parent)
       : QCreatable(pCre, kLayer, parent)

--- a/src/PrpShop/PRP/Surface/QLayer.h
+++ b/src/PrpShop/PRP/Surface/QLayer.h
@@ -17,15 +17,15 @@
 #ifndef _QLAYER_H
 #define _QLAYER_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Surface/plLayer.h>
 #include <QCheckBox>
 #include <QSpinBox>
 #include <QLineEdit>
-#include "../QObjLink.h"
-#include "../QColorEdit.h"
-#include "../QMatrix44.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QMatrix44.h"
+#include "QColorEdit.h"
 
 class QLayer : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Surface/QLayerAnimation.cpp
+++ b/src/PrpShop/PRP/Surface/QLayerAnimation.cpp
@@ -21,8 +21,8 @@
 #include <QGridLayout>
 #include <QSpacerItem>
 #include <ResManager/plFactory.h>
-#include "../../Main.h"
-#include "../../QKeyDialog.h"
+#include "Main.h"
+#include "QKeyDialog.h"
 
 QLayerAnimation::QLayerAnimation(plCreatable* pCre, QWidget* parent)
                : QCreatable(pCre, kLayerAnimation, parent)

--- a/src/PrpShop/PRP/Surface/QLayerAnimation.h
+++ b/src/PrpShop/PRP/Surface/QLayerAnimation.h
@@ -17,12 +17,12 @@
 #ifndef _QLAYERANIMATION_H
 #define _QLAYERANIMATION_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Surface/plLayerAnimation.h>
-#include "../QObjLink.h"
-#include "../QColorEdit.h"
-#include "../QMatrix44.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QMatrix44.h"
+#include "QColorEdit.h"
 
 class QLayerAnimation : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Surface/QLayerLinkAnimation.cpp
+++ b/src/PrpShop/PRP/Surface/QLayerLinkAnimation.cpp
@@ -18,9 +18,9 @@
 
 #include <QLabel>
 #include <QGridLayout>
-#include "../../Main.h"
-#include "../../QKeyDialog.h"
-#include "../../../QPlasma.h"
+#include "Main.h"
+#include "QKeyDialog.h"
+#include "QPlasma.h"
 
 QLayerLinkAnimation::QLayerLinkAnimation(plCreatable* pCre, QWidget* parent)
                    : QCreatable(pCre, kLayerLinkAnimation, parent)

--- a/src/PrpShop/PRP/Surface/QLayerLinkAnimation.h
+++ b/src/PrpShop/PRP/Surface/QLayerLinkAnimation.h
@@ -17,11 +17,11 @@
 #ifndef _QLAYERLINKANIMATION_H
 #define _QLAYERLINKANIMATION_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Surface/plLayerAnimation.h>
 #include <QCheckBox>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QLayerLinkAnimation : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Surface/QLayerMovie.h
+++ b/src/PrpShop/PRP/Surface/QLayerMovie.h
@@ -17,11 +17,11 @@
 #ifndef _QLAYERMOVIE_H
 #define _QLAYERMOVIE_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Surface/plLayerMovie.h>
 #include <QLineEdit>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QLayerMovie : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Surface/QLayerSDLAnimation.h
+++ b/src/PrpShop/PRP/Surface/QLayerSDLAnimation.h
@@ -17,11 +17,11 @@
 #ifndef _QLAYERSDLANIMATION_H
 #define _QLAYERSDLANIMATION_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Surface/plLayerAnimation.h>
 #include <QLineEdit>
-#include "../QObjLink.h"
+#include "PRP/QObjLink.h"
 
 class QLayerSDLAnimation : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Surface/QMaterial.h
+++ b/src/PrpShop/PRP/Surface/QMaterial.h
@@ -17,12 +17,12 @@
 #ifndef _QMATERIAL_H
 #define _QMATERIAL_H
 
-#include "../QCreatable.h"
+#include "PRP/QCreatable.h"
 
 #include <PRP/Surface/hsGMaterial.h>
 #include <QCheckBox>
-#include "../QObjLink.h"
-#include "../QKeyList.h"
+#include "PRP/QObjLink.h"
+#include "PRP/QKeyList.h"
 
 class QMaterial : public QCreatable {
     Q_OBJECT

--- a/src/PrpShop/PRP/Surface/QMipmap.cpp
+++ b/src/PrpShop/PRP/Surface/QMipmap.cpp
@@ -25,8 +25,8 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <Util/plDDSurface.h>
-#include "../QLinkLabel.h"
-#include "../../QPlasmaUtils.h"
+#include "QLinkLabel.h"
+#include "QPlasmaUtils.h"
 
 /* Helpers */
 static QString getExportDir()

--- a/src/PrpShop/PRP/Surface/QMipmap.h
+++ b/src/PrpShop/PRP/Surface/QMipmap.h
@@ -17,8 +17,8 @@
 #ifndef _QMIPMAP_H
 #define _QMIPMAP_H
 
-#include "../QCreatable.h"
-#include "../QObjLink.h"
+#include "PRP/QCreatable.h"
+#include "PRP/QObjLink.h"
 #include <QImage>
 #include <QCheckBox>
 #include <QSpinBox>

--- a/src/PrpShop/QHexViewer.cpp
+++ b/src/PrpShop/QHexViewer.cpp
@@ -22,7 +22,7 @@
 #include <QStatusBar>
 #include <QFile>
 #include <Stream/hsRAMStream.h>
-#include "../QHexWidget.h"
+#include "QHexWidget.h"
 
 class SelectableLabel : public QLabel
 {

--- a/src/PrpShop/QPlasmaUtils.h
+++ b/src/PrpShop/QPlasmaUtils.h
@@ -21,8 +21,8 @@
 #include <vector>
 #include <ResManager/pdUnifiedTypeMap.h>
 #include <PRP/plCreatable.h>
-#include "../QPlasma.h"
-#include "../QNumerics.h"
+#include "QPlasma.h"
+#include "QNumerics.h"
 
 extern bool s_showTypeIDs;
 

--- a/src/PrpShop/QPrcEditor.cpp
+++ b/src/PrpShop/QPrcEditor.cpp
@@ -26,7 +26,7 @@
 #include <ResManager/plResManager.h>
 #include <Stream/hsRAMStream.h>
 #include <PRP/KeyedObject/hsKeyedObject.h>
-#include "../QPlasma.h"
+#include "QPlasma.h"
 #include "Main.h"
 
 #define MARGIN_LINES 0

--- a/src/VaultShop/CMakeLists.txt
+++ b/src/VaultShop/CMakeLists.txt
@@ -1,7 +1,5 @@
-set(VaultShop_MOC_Headers
+set(VaultShop_Headers
     Main.h
-    ../QColorEdit.h
-    ../QLinkLabel.h
     QGameServerState.h
     QVaultNode.h
     QVaultNodeEdit.h
@@ -19,8 +17,6 @@ set(VaultShop_MOC_Headers
 
 set(VaultShop_Sources
     Main.cpp
-    ../QColorEdit.cpp
-    ../QLinkLabel.cpp
     QGameServerState.cpp
     QVaultNode.cpp
     QVaultNodeEdit.cpp
@@ -36,37 +32,20 @@ set(VaultShop_Sources
     QVaultImageNode.cpp
 )
 
-if(NOT WIN32 AND NOT APPLE)
-    set(VaultShop_Sources "${VaultShop_Sources}"
-        ../3rdParty/qticonloader.cpp
-    )
-endif()
-
 #if(WIN32)
 #    set(VaultShop_Sources ${VaultShop_Sources} res/VaultShop.rc)
 #endif()
 
-if(PS_USE_QT5)
-    find_package(Qt5Widgets REQUIRED)
-endif()
-
 # generate rules for building source files from the resources
-qtx_add_resources(VaultShop_RCC images.qrc)
-# generate rules for building source files that moc generates
-qtx_wrap_cpp(VaultShop_MOC "${VaultShop_MOC_Headers}")
-
-include_directories("${PROJECT_SOURCE_DIR}/src/3rdParty")
-include_directories("${HSPlasma_INCLUDE_DIRS}")
+qt5_add_resources(VaultShop_RCC images.qrc)
 
 add_executable(VaultShop WIN32 MACOSX_BUNDLE
-               ${VaultShop_Sources} ${VaultShop_MOC} ${VaultShop_RCC})
-if(PS_USE_QT5)
-    target_link_libraries(VaultShop Qt5::Widgets)
-elseif(PS_USE_QT4)
-    target_link_libraries(VaultShop ${QT_QTMAIN_LIBRARY} ${QT_QTCORE_LIBRARY}
-                                    ${QT_QTGUI_LIBRARY})
-endif()
+               ${VaultShop_Sources} ${VaultShop_Headers} ${VaultShop_RCC})
+target_link_libraries(VaultShop PSCommon Qt5::Widgets)
 target_link_libraries(VaultShop HSPlasma)
+if(NOT WIN32 AND NOT APPLE)
+    target_link_libraries(VaultShop PSIconLoader)
+endif()
 
 if(APPLE)
     set(MACOSX_BUNDLE true)

--- a/src/VaultShop/Main.cpp
+++ b/src/VaultShop/Main.cpp
@@ -29,7 +29,7 @@
 #include <ResManager/plFactory.h>
 
 #include "Main.h"
-#include "../QPlasma.h"
+#include "QPlasma.h"
 
 static QString HexToStr(const QString& hex)
 {

--- a/src/VaultShop/QVaultAgeInfoNode.h
+++ b/src/VaultShop/QVaultAgeInfoNode.h
@@ -20,7 +20,7 @@
 #include <QLineEdit>
 #include <QSpinBox>
 #include "QVaultNodeEdit.h"
-#include "../QLinkLabel.h"
+#include "QLinkLabel.h"
 
 class QVaultAgeInfoNode : public QVaultNodeEdit {
     Q_OBJECT

--- a/src/VaultShop/QVaultNodeEdit.h
+++ b/src/VaultShop/QVaultNodeEdit.h
@@ -21,7 +21,7 @@
 #include <Vault/plVaultNode.h>
 #include <SDL/plSDLMgr.h>
 #include <ResManager/plResManager.h>
-#include "../QPlasma.h"
+#include "QPlasma.h"
 
 class QVaultNodeEdit : public QWidget {
     Q_OBJECT

--- a/src/VaultShop/QVaultPlayerInfoNode.h
+++ b/src/VaultShop/QVaultPlayerInfoNode.h
@@ -20,7 +20,7 @@
 #include <QLineEdit>
 #include <QSpinBox>
 #include "QVaultNodeEdit.h"
-#include "../QLinkLabel.h"
+#include "QLinkLabel.h"
 
 class QVaultPlayerInfoNode : public QVaultNodeEdit {
     Q_OBJECT

--- a/src/VaultShop/QVaultSDLNode.h
+++ b/src/VaultShop/QVaultSDLNode.h
@@ -29,7 +29,7 @@
 #include <SDL/plStateDataRecord.h>
 #include <ResManager/plResManager.h>
 #include "QVaultNodeEdit.h"
-#include "../QColorEdit.h"
+#include "QColorEdit.h"
 
 class QSDLEditor : public QWidget {
     Q_OBJECT


### PR DESCRIPTION
Clean up some long standing technical debt in PlasmaShop:
* Remove support for Qt4.  It's old enough now that we can start requiring Qt5, and things like [this](https://github.com/H-uru/PlasmaShop/commit/e7aea5dbd25c4595b28a55b8582663a14e9c8dcc#diff-5a4fcc9997cab31b19986c429f9c56b5R56) break Qt4 anyway.
* Don't use parent-relative includes.
* Don't compile common files more than once.

This change set shouldn't result in any changed behavior, just a cleaner build system.