### PR TITLE
More accurate label for kZIncLayer flag

### DIFF
--- a/src/PrpShop/PRP/Surface/QLayer.cpp
+++ b/src/PrpShop/PRP/Surface/QLayer.cpp
@@ -112,7 +112,7 @@ QLayer::QLayer(plCreatable* pCre, QWidget* parent)
     clampZLayout->setHorizontalSpacing(8);
     fClampFlags[kClampTextureU] = new QCheckBox(tr("Clamp Texture U"), clampZWidget);
     fClampFlags[kClampTextureV] = new QCheckBox(tr("Clamp Texture V"), clampZWidget);
-    fZFlags[kZIncLayer] = new QCheckBox(tr("Include Z Layer"), clampZWidget);
+    fZFlags[kZIncLayer] = new QCheckBox(tr("Increment Z Layer"), clampZWidget);
     fZFlags[kZClearZ] = new QCheckBox(tr("Clear Z"), clampZWidget);
     fZFlags[kZNoZRead] = new QCheckBox(tr("No Z Read"), clampZWidget);
     fZFlags[kZNoZWrite] = new QCheckBox(tr("No Z Write"), clampZWidget);


### PR DESCRIPTION
According to [a comment](https://github.com/H-uru/Plasma/blob/76f136261c9bc88b3cb6e9e70e63f54e64bcd416/Sources/Plasma/PubUtilLib/plPipeline/DX/plDXPipeline.cpp#L6557) in plDXPipeline,
> ZIncLayer requests Z bias for upper layers.