### PR TITLE
use https to fetch pycdc submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pycdc"]
 	path = pycdc
-	url = git://github.com/zrax/pycdc
+	url = https://github.com/zrax/pycdc


### PR DESCRIPTION
Because, you know, making everything as encrypted as possible :)