### PR TITLE
Use explicit Python executable to launch pycdc script.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(Qt5Core REQUIRED)
 find_package(Qt5Gui REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 find_package(KF5SyntaxHighlighting REQUIRED)
+find_package(PythonInterp REQUIRED)
 
 if(KF5SyntaxHighlighting_VERSION VERSION_LESS "5.39.0")
     message(WARNING "KF5SyntaxHighlighting version 5.39.0 or later is required \

--- a/src/PlasmaShop/CMakeLists.txt
+++ b/src/PlasmaShop/CMakeLists.txt
@@ -103,7 +103,7 @@ set(pycdc_GeneratedSources
 add_custom_target(create-bytes-source-dir ALL
                   COMMAND ${CMAKE_COMMAND} -E make_directory ${pycdc_BINARY_DIR}/bytes)
 add_custom_command(OUTPUT ${pycdc_GeneratedSources}
-                   COMMAND ${pycdc_SOURCE_DIR}/bytes/comp_map.py
+                   COMMAND ${PYTHON_EXECUTABLE} ${pycdc_SOURCE_DIR}/bytes/comp_map.py
                            ${pycdc_SOURCE_DIR}/bytes ${pycdc_BINARY_DIR}/bytes
                    DEPENDS ${pycdc_Maps} ${pycdc_SOURCE_DIR}/bytes/comp_map.py
                            create-bytes-source-dir


### PR DESCRIPTION
This fixes a situation where the script, rather than being executed, is opened in the associated text editor (or any other number of configuration possibilities, depending on the system in question) causing both an unexpected event as well as a silent failure to build the required files.