### PR TITLE
BGRA Fixes

### DIFF
--- a/src/PrpShop/PRP/Surface/QMipmap.cpp
+++ b/src/PrpShop/PRP/Surface/QMipmap.cpp
@@ -343,6 +343,8 @@ QMipmap::QMipmap(plCreatable* pCre, QWidget* parent)
 
 static void swapColorChannels(unsigned char* data, size_t size)
 {
+    Q_ASSERT(reinterpret_cast<uintptr_t>(data) % sizeof(unsigned int) == 0);
+
     unsigned int* dp = reinterpret_cast<unsigned int*>(data);
     for (size_t i=0; i<size; i += 4) {
         *dp = (*dp & 0xFF00FF00)

--- a/src/PrpShop/PRP/Surface/QMipmap.cpp
+++ b/src/PrpShop/PRP/Surface/QMipmap.cpp
@@ -193,6 +193,19 @@ QString getCompressionText(plBitmap* tex)
         case plBitmap::kAInten88:
             return "JPEG (Alpha+Greyscale)";
         }
+    } else if (tex->getCompressionType() == plBitmap::kPNGCompression) {
+        switch (tex->getARGBType()) {
+        case plBitmap::kRGB8888:
+            return "PNG (ARGB8888)";
+        case plBitmap::kRGB4444:
+            return "PNG (ARGB4444)";
+        case plBitmap::kRGB1555:
+            return "PNG (ARGB1555)";
+        case plBitmap::kInten8:
+            return "PNG (Greyscale)";
+        case plBitmap::kAInten88:
+            return "PNG (Alpha+Greyscale)";
+        }
     } else {
         switch (tex->getARGBType()) {
         case plBitmap::kRGB8888:

--- a/src/PrpShop/PRP/Surface/QMipmap.cpp
+++ b/src/PrpShop/PRP/Surface/QMipmap.cpp
@@ -343,7 +343,7 @@ QMipmap::QMipmap(plCreatable* pCre, QWidget* parent)
 
 static void swapColorChannels(unsigned char* data, size_t size)
 {
-    Q_ASSERT(reinterpret_cast<uintptr_t>(data) % sizeof(unsigned int) == 0);
+    Q_ASSERT(reinterpret_cast<uintptr_t>(data) % alignof(unsigned int) == 0);
 
     unsigned int* dp = reinterpret_cast<unsigned int*>(data);
     for (size_t i=0; i<size; i += 4) {


### PR DESCRIPTION
Plasma stores its image data in `plMipmap` as BGR(A), with the exception of DXT formatted data. This changeset updates PRPShop to match the fixes in libHSPlasma in that regard. Also teaches PRPShop about PNG compressed images. I believe a more complete changeset from @Deledrius is incoming to improve the import/export image options.

Depends on:
- H-uru/libhsplasma#126
- H-uru/libhsplasma#127