### PR TITLE
Commit QCheckBox changes immediately.

### DIFF
--- a/src/PrpShop/CMakeLists.txt
+++ b/src/PrpShop/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(PrpShop_Headers
     Main.h
+    QBitmaskCheckBox.h
     QKeyDialog.h
     QPrcEditor.h
     QHexViewer.h
@@ -66,6 +67,7 @@ set(PrpShop_Headers
 
 set(PrpShop_Sources
     Main.cpp
+    QBitmaskCheckBox.cpp
     QKeyDialog.cpp
     QPlasmaUtils.cpp
     QPlasmaTreeItem.cpp

--- a/src/PrpShop/PRP/Animation/QAnimTimeConvert.cpp
+++ b/src/PrpShop/PRP/Animation/QAnimTimeConvert.cpp
@@ -136,22 +136,22 @@ QAnimTimeConvert::QAnimTimeConvert(plCreatable* pCre, QWidget* parent)
     QGridLayout* flagLayout = new QGridLayout(flagGroup);
     flagLayout->setVerticalSpacing(0);
     flagLayout->setHorizontalSpacing(8);
-    fFlags[kStopped] = new QCheckBox(tr("Stopped"), flagGroup);
-    fFlags[kLoop] = new QCheckBox(tr("Loop"), flagGroup);
-    fFlags[kBackwards] = new QCheckBox(tr("Backwards"), flagGroup);
-    fFlags[kWrap] = new QCheckBox(tr("Wrap"), flagGroup);
-    fFlags[kNeedsReset] = new QCheckBox(tr("Needs Reset"), flagGroup);
-    fFlags[kEasingIn] = new QCheckBox(tr("Easing In"), flagGroup);
-    fFlags[kForcedMove] = new QCheckBox(tr("Forced Move"), flagGroup);
-    fFlags[kNoCallbacks] = new QCheckBox(tr("No Callbacks"), flagGroup);
-    fFlags[kStopped]->setChecked((obj->getFlags() & plAnimTimeConvert::kStopped) != 0);
-    fFlags[kLoop]->setChecked((obj->getFlags() & plAnimTimeConvert::kLoop) != 0);
-    fFlags[kBackwards]->setChecked((obj->getFlags() & plAnimTimeConvert::kBackwards) != 0);
-    fFlags[kWrap]->setChecked((obj->getFlags() & plAnimTimeConvert::kWrap) != 0);
-    fFlags[kNeedsReset]->setChecked((obj->getFlags() & plAnimTimeConvert::kNeedsReset) != 0);
-    fFlags[kEasingIn]->setChecked((obj->getFlags() & plAnimTimeConvert::kEasingIn) != 0);
-    fFlags[kForcedMove]->setChecked((obj->getFlags() & plAnimTimeConvert::kForcedMove) != 0);
-    fFlags[kNoCallbacks]->setChecked((obj->getFlags() & plAnimTimeConvert::kNoCallbacks) != 0);
+    fFlags[kStopped] = new QBitmaskCheckBox(plAnimTimeConvert::kStopped,
+                                            tr("Stopped"), flagGroup);
+    fFlags[kLoop] = new QBitmaskCheckBox(plAnimTimeConvert::kLoop, tr("Loop"),
+                                         flagGroup);
+    fFlags[kBackwards] = new QBitmaskCheckBox(plAnimTimeConvert::kBackwards,
+                                              tr("Backwards"), flagGroup);
+    fFlags[kWrap] = new QBitmaskCheckBox(plAnimTimeConvert::kWrap, tr("Wrap"),
+                                         flagGroup);
+    fFlags[kNeedsReset] = new QBitmaskCheckBox(plAnimTimeConvert::kNeedsReset,
+                                               tr("Needs Reset"), flagGroup);
+    fFlags[kEasingIn] = new QBitmaskCheckBox(plAnimTimeConvert::kEasingIn,
+                                             tr("Easing In"), flagGroup);
+    fFlags[kForcedMove] = new QBitmaskCheckBox(plAnimTimeConvert::kForcedMove,
+                                               tr("Forced Move"), flagGroup);
+    fFlags[kNoCallbacks] = new QBitmaskCheckBox(plAnimTimeConvert::kNoCallbacks,
+                                                tr("No Callbacks"), flagGroup);
     flagLayout->addWidget(fFlags[kStopped], 0, 0);
     flagLayout->addWidget(fFlags[kLoop], 0, 1);
     flagLayout->addWidget(fFlags[kBackwards], 0, 2);
@@ -160,6 +160,17 @@ QAnimTimeConvert::QAnimTimeConvert(plCreatable* pCre, QWidget* parent)
     flagLayout->addWidget(fFlags[kEasingIn], 1, 1);
     flagLayout->addWidget(fFlags[kForcedMove], 1, 2);
     flagLayout->addWidget(fFlags[kNoCallbacks], 1, 3);
+    for (auto cb : fFlags) {
+        cb->setFrom(obj->getFlags());
+        connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            plAnimTimeConvert* obj = plAnimTimeConvert::Convert(fCreatable);
+            obj->setFlags(obj->getFlags() | mask);
+        });
+        connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            plAnimTimeConvert* obj = plAnimTimeConvert::Convert(fCreatable);
+            obj->setFlags(obj->getFlags() & ~mask);
+        });
+    }
 
     QGroupBox* timeGroup = new QGroupBox(tr("Timing Parameters"), this);
     QGridLayout* timeLayout = new QGridLayout(timeGroup);
@@ -245,16 +256,8 @@ QAnimTimeConvert::QAnimTimeConvert(plCreatable* pCre, QWidget* parent)
 
 void QAnimTimeConvert::saveDamage()
 {
-    plAnimTimeConvert* obj = (plAnimTimeConvert*)fCreatable;
+    plAnimTimeConvert* obj = plAnimTimeConvert::Convert(fCreatable);
 
-    obj->setFlags((fFlags[kStopped]->isChecked() ? plAnimTimeConvert::kStopped : 0)
-                | (fFlags[kLoop]->isChecked() ? plAnimTimeConvert::kLoop : 0)
-                | (fFlags[kBackwards]->isChecked() ? plAnimTimeConvert::kBackwards : 0)
-                | (fFlags[kWrap]->isChecked() ? plAnimTimeConvert::kWrap : 0)
-                | (fFlags[kNeedsReset]->isChecked() ? plAnimTimeConvert::kNeedsReset : 0)
-                | (fFlags[kEasingIn]->isChecked() ? plAnimTimeConvert::kEasingIn : 0)
-                | (fFlags[kForcedMove]->isChecked() ? plAnimTimeConvert::kForcedMove : 0)
-                | (fFlags[kNoCallbacks]->isChecked() ? plAnimTimeConvert::kNoCallbacks : 0));
     obj->setRange(fBegin->value(), fEnd->value());
     obj->setLoop(fLoopBegin->value(), fLoopEnd->value());
     obj->setSpeed(fSpeed->value());

--- a/src/PrpShop/PRP/Animation/QAnimTimeConvert.h
+++ b/src/PrpShop/PRP/Animation/QAnimTimeConvert.h
@@ -21,7 +21,7 @@
 
 #include <PRP/Animation/plAnimTimeConvert.h>
 #include <QLineEdit>
-#include <QCheckBox>
+#include "QBitmaskCheckBox.h"
 #include "PRP/QObjLink.h"
 #include "PRP/QKeyList.h"
 
@@ -65,7 +65,7 @@ protected:
         kStopped, kLoop, kBackwards, kWrap, kNeedsReset, kEasingIn, kForcedMove,
         kNoCallbacks, kNumATCFlags
     };
-    QCheckBox* fFlags[kNumATCFlags];
+    QBitmaskCheckBox* fFlags[kNumATCFlags];
 
     QFloatEdit* fBegin;
     QFloatEdit* fEnd;

--- a/src/PrpShop/PRP/Audio/QAudible.h
+++ b/src/PrpShop/PRP/Audio/QAudible.h
@@ -27,7 +27,6 @@ class QAudible : public QCreatable
 
 public:
     QAudible(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 };
 
 class QWinAudible : public QCreatable

--- a/src/PrpShop/PRP/Audio/QWinSound.cpp
+++ b/src/PrpShop/PRP/Audio/QWinSound.cpp
@@ -213,24 +213,24 @@ QWinSound::QWinSound(plCreatable* pCre, QWidget* parent)
     QGridLayout* layProperties = new QGridLayout(grpProperties);
     layProperties->setVerticalSpacing(0);
     layProperties->setHorizontalSpacing(8);
-    fProperties[kPropIs3DSound] = new QCheckBox(tr("Is 3D Sound"), grpProperties);
-    fProperties[kPropDisableLOD] = new QCheckBox(tr("Disable LOD"), grpProperties);
-    fProperties[kPropLooping] = new QCheckBox(tr("Looping"), grpProperties);
-    fProperties[kPropAutoStart] = new QCheckBox(tr("Auto Start"), grpProperties);
-    fProperties[kPropLocalOnly] = new QCheckBox(tr("Local Only"), grpProperties);
-    fProperties[kPropLoadOnlyOnCall] = new QCheckBox(tr("Load Only on Call"), grpProperties);
-    fProperties[kPropFullyDisabled] = new QCheckBox(tr("Fully Disabled"), grpProperties);
-    fProperties[kPropDontFade] = new QCheckBox(tr("Don't Fade"), grpProperties);
-    fProperties[kPropIncidental] = new QCheckBox(tr("Incidental"), grpProperties);
-    fProperties[kPropIs3DSound]->setChecked((obj->getProperties() & plSound::kPropIs3DSound) != 0);
-    fProperties[kPropDisableLOD]->setChecked((obj->getProperties() & plSound::kPropDisableLOD) != 0);
-    fProperties[kPropLooping]->setChecked((obj->getProperties() & plSound::kPropLooping) != 0);
-    fProperties[kPropAutoStart]->setChecked((obj->getProperties() & plSound::kPropAutoStart) != 0);
-    fProperties[kPropLocalOnly]->setChecked((obj->getProperties() & plSound::kPropLocalOnly) != 0);
-    fProperties[kPropLoadOnlyOnCall]->setChecked((obj->getProperties() & plSound::kPropLoadOnlyOnCall) != 0);
-    fProperties[kPropFullyDisabled]->setChecked((obj->getProperties() & plSound::kPropFullyDisabled) != 0);
-    fProperties[kPropDontFade]->setChecked((obj->getProperties() & plSound::kPropDontFade) != 0);
-    fProperties[kPropIncidental]->setChecked((obj->getProperties() & plSound::kPropIncidental) != 0);
+    fProperties[kPropIs3DSound] = new QBitmaskCheckBox(plSound::kPropIs3DSound,
+            tr("Is 3D Sound"), grpProperties);
+    fProperties[kPropDisableLOD] = new QBitmaskCheckBox(plSound::kPropDisableLOD,
+            tr("Disable LOD"), grpProperties);
+    fProperties[kPropLooping] = new QBitmaskCheckBox(plSound::kPropLooping,
+            tr("Looping"), grpProperties);
+    fProperties[kPropAutoStart] = new QBitmaskCheckBox(plSound::kPropAutoStart,
+            tr("Auto Start"), grpProperties);
+    fProperties[kPropLocalOnly] = new QBitmaskCheckBox(plSound::kPropLocalOnly,
+            tr("Local Only"), grpProperties);
+    fProperties[kPropLoadOnlyOnCall] = new QBitmaskCheckBox(plSound::kPropLoadOnlyOnCall,
+            tr("Load Only on Call"), grpProperties);
+    fProperties[kPropFullyDisabled] = new QBitmaskCheckBox(plSound::kPropFullyDisabled,
+            tr("Fully Disabled"), grpProperties);
+    fProperties[kPropDontFade] = new QBitmaskCheckBox(plSound::kPropDontFade,
+            tr("Don't Fade"), grpProperties);
+    fProperties[kPropIncidental] = new QBitmaskCheckBox(plSound::kPropIncidental,
+            tr("Incidental"), grpProperties);
     layProperties->addWidget(fProperties[kPropIs3DSound], 0, 0);
     layProperties->addWidget(fProperties[kPropDisableLOD], 1, 0);
     layProperties->addWidget(fProperties[kPropLooping], 2, 0);
@@ -240,6 +240,17 @@ QWinSound::QWinSound(plCreatable* pCre, QWidget* parent)
     layProperties->addWidget(fProperties[kPropFullyDisabled], 0, 2);
     layProperties->addWidget(fProperties[kPropDontFade], 1, 2);
     layProperties->addWidget(fProperties[kPropIncidental], 2, 2);
+    for (auto prop : fProperties) {
+        prop->setFrom(obj->getProperties());
+        connect(prop, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            plSound* obj = plSound::Convert(fCreatable);
+            obj->setProperties(obj->getProperties() | mask);
+        });
+        connect(prop, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            plSound* obj = plSound::Convert(fCreatable);
+            obj->setProperties(obj->getProperties() & ~mask);
+        });
+    }
 
     QGroupBox* grpFadeIn = new QGroupBox(tr("Fade In Parameters"), this);
     QGridLayout* layFadeIn = new QGridLayout(grpFadeIn);
@@ -386,15 +397,6 @@ void QWinSound::saveDamage()
     obj->setPriority(fPriority->value());
     obj->setPlaying(fPlaying->isChecked());
     obj->setSubtitleId(qstr2st(fSubtitleId->text()));
-    obj->setProperties((fProperties[kPropIs3DSound]->isChecked() ? plSound::kPropIs3DSound : 0)
-                     | (fProperties[kPropDisableLOD]->isChecked() ? plSound::kPropDisableLOD : 0)
-                     | (fProperties[kPropLooping]->isChecked() ? plSound::kPropLooping : 0)
-                     | (fProperties[kPropAutoStart]->isChecked() ? plSound::kPropAutoStart : 0)
-                     | (fProperties[kPropLocalOnly]->isChecked() ? plSound::kPropLocalOnly : 0)
-                     | (fProperties[kPropLoadOnlyOnCall]->isChecked() ? plSound::kPropLoadOnlyOnCall : 0)
-                     | (fProperties[kPropFullyDisabled]->isChecked() ? plSound::kPropFullyDisabled : 0)
-                     | (fProperties[kPropDontFade]->isChecked() ? plSound::kPropDontFade : 0)
-                     | (fProperties[kPropIncidental]->isChecked() ? plSound::kPropIncidental : 0));
     obj->getFadeInParams().fLengthInSecs = fFadeInParams.fLength->value();
     obj->getFadeInParams().fVolStart = fFadeInParams.fVolStart->value();
     obj->getFadeInParams().fVolEnd = fFadeInParams.fVolEnd->value();

--- a/src/PrpShop/PRP/Audio/QWinSound.cpp
+++ b/src/PrpShop/PRP/Audio/QWinSound.cpp
@@ -137,12 +137,17 @@ QEaxSourceSettings::QEaxSourceSettings(plEAXSourceSettings* eax, QWidget* parent
     fSoftEnds.fRoomRatio->setValue(fEaxObject->getSoftEnds().getRoomRatio());
     fSoftEnds.fDirectRatio->setValue(fEaxObject->getSoftEnds().getDirectRatio());
     fEnabled->setChecked(fEaxObject->isEnabled());
+
+    connect(fRoomAuto, &QCheckBox::clicked, [this](bool checked) {
+        fEaxObject->setRoomAuto(checked);
+    });
+    connect(fRoomHFAuto, &QCheckBox::clicked, [this](bool checked) {
+        fEaxObject->setRoomHFAuto(checked);
+    });
 }
 
 void QEaxSourceSettings::saveDamage()
 {
-    fEaxObject->setRoomAuto(fRoomAuto->isChecked());
-    fEaxObject->setRoomHFAuto(fRoomHFAuto->isChecked());
     fEaxObject->setRoom(fRoom->value());
     fEaxObject->setRoomHF(fRoomHF->value());
     fEaxObject->setOutsideVolHF(fOutsideVolHF->value());
@@ -208,6 +213,11 @@ QWinSound::QWinSound(plCreatable* pCre, QWidget* parent)
     fPriority->setValue(obj->getPriority());
     fPlaying->setChecked(obj->isPlaying());
     fSubtitleId->setText(st2qstr(obj->getSubtitleId()));
+
+    connect(fPlaying, &QCheckBox::clicked, [this](bool checked) {
+        plSound* obj = plSound::Convert(fCreatable);
+        obj->setPlaying(checked);
+    });
 
     QGroupBox* grpProperties = new QGroupBox(tr("Properties"), this);
     QGridLayout* layProperties = new QGridLayout(grpProperties);
@@ -284,6 +294,15 @@ QWinSound::QWinSound(plCreatable* pCre, QWidget* parent)
     layFadeIn->addWidget(fFadeInParams.fStopWhenDone, 5, 0, 1, 2);
     layFadeIn->addWidget(fFadeInParams.fFadeSoftVol, 6, 0, 1, 2);
 
+    connect(fFadeInParams.fStopWhenDone, &QCheckBox::clicked, [this](bool checked) {
+        plSound* obj = plSound::Convert(fCreatable);
+        obj->getFadeInParams().fStopWhenDone = checked;
+    });
+    connect(fFadeInParams.fFadeSoftVol, &QCheckBox::clicked, [this](bool checked) {
+        plSound* obj = plSound::Convert(fCreatable);
+        obj->getFadeInParams().fFadeSoftVol = checked;
+    });
+
     QGroupBox* grpFadeOut = new QGroupBox(tr("Fade Out Parameters"), this);
     QGridLayout* layFadeOut = new QGridLayout(grpFadeOut);
     layFadeOut->setVerticalSpacing(4);
@@ -315,6 +334,15 @@ QWinSound::QWinSound(plCreatable* pCre, QWidget* parent)
     layFadeOut->addWidget(fFadeOutParams.fCurrTime, 4, 1);
     layFadeOut->addWidget(fFadeOutParams.fStopWhenDone, 5, 0, 1, 2);
     layFadeOut->addWidget(fFadeOutParams.fFadeSoftVol, 6, 0, 1, 2);
+
+    connect(fFadeOutParams.fStopWhenDone, &QCheckBox::clicked, [this](bool checked) {
+        plSound* obj = plSound::Convert(fCreatable);
+        obj->getFadeOutParams().fStopWhenDone = checked;
+    });
+    connect(fFadeOutParams.fFadeSoftVol, &QCheckBox::clicked, [this](bool checked) {
+        plSound* obj = plSound::Convert(fCreatable);
+        obj->getFadeOutParams().fFadeSoftVol = checked;
+    });
 
     fSoftRegion = new QCreatableLink(this);
     fSoftRegion->setKey(obj->getSoftRegion());
@@ -395,22 +423,17 @@ void QWinSound::saveDamage()
     obj->setCone(fInnerCone->value(), fOuterCone->value());
     obj->setFadedVolume(fFadedVolume->value());
     obj->setPriority(fPriority->value());
-    obj->setPlaying(fPlaying->isChecked());
     obj->setSubtitleId(qstr2st(fSubtitleId->text()));
     obj->getFadeInParams().fLengthInSecs = fFadeInParams.fLength->value();
     obj->getFadeInParams().fVolStart = fFadeInParams.fVolStart->value();
     obj->getFadeInParams().fVolEnd = fFadeInParams.fVolEnd->value();
     obj->getFadeInParams().fType = fFadeInParams.fType->currentIndex();
     obj->getFadeInParams().fCurrTime = fFadeInParams.fCurrTime->value();
-    obj->getFadeInParams().fStopWhenDone = fFadeInParams.fStopWhenDone->isChecked();
-    obj->getFadeInParams().fFadeSoftVol = fFadeInParams.fFadeSoftVol->isChecked();
     obj->getFadeOutParams().fLengthInSecs = fFadeOutParams.fLength->value();
     obj->getFadeOutParams().fVolStart = fFadeOutParams.fVolStart->value();
     obj->getFadeOutParams().fVolEnd = fFadeOutParams.fVolEnd->value();
     obj->getFadeOutParams().fType = fFadeOutParams.fType->currentIndex();
     obj->getFadeOutParams().fCurrTime = fFadeOutParams.fCurrTime->value();
-    obj->getFadeOutParams().fStopWhenDone = fFadeOutParams.fStopWhenDone->isChecked();
-    obj->getFadeOutParams().fFadeSoftVol = fFadeOutParams.fFadeSoftVol->isChecked();
 }
 
 void QWinSound::setSoftRegion()

--- a/src/PrpShop/PRP/Audio/QWinSound.h
+++ b/src/PrpShop/PRP/Audio/QWinSound.h
@@ -21,7 +21,7 @@
 
 #include <PRP/Audio/plEAXEffects.h>
 #include <QComboBox>
-#include <QCheckBox>
+#include "QBitmaskCheckBox.h"
 #include "PRP/QObjLink.h"
 
 class QEaxSourceSettings : public QWidget
@@ -87,7 +87,7 @@ protected:
         kPropLocalOnly, kPropLoadOnlyOnCall, kPropFullyDisabled, kPropDontFade,
         kPropIncidental, kNumProps
     };
-    QCheckBox* fProperties[kNumProps];
+    QBitmaskCheckBox* fProperties[kNumProps];
 
     // Fade Params
     struct

--- a/src/PrpShop/PRP/Avatar/QAvLadderMod.cpp
+++ b/src/PrpShop/PRP/Avatar/QAvLadderMod.cpp
@@ -37,12 +37,15 @@ QAvLadderMod::QAvLadderMod(plCreatable* pCre, QWidget* parent)
     fGoingUp = new QButtonGroup(this);
     fLadderView = new QVector3(this);
 
-
     QGridLayout* layout = new QGridLayout(this);
     layout->setContentsMargins(8, 8, 8, 8);
 
     layout->addWidget(fEnabled, 1, 3, 1, 3, Qt::AlignRight);
     fEnabled->setChecked(mod->isEnabled());
+    connect(fEnabled, &QCheckBox::clicked, this, [this](bool checked) {
+        plAvLadderMod* mod = plAvLadderMod::Convert(fCreatable);
+        mod->setEnabled(checked);
+    });
 
     layout->addWidget(new QLabel(tr("Type:"), this), 1, 0);
     layout->addWidget(fType, 1, 1, 1, 2);
@@ -85,7 +88,6 @@ void QAvLadderMod::saveDamage()
 {
     plAvLadderMod* mod = plAvLadderMod::Convert(fCreatable);
 
-    mod->setEnabled(fEnabled->isChecked());
     mod->setGoingUp(fGoingUp->checkedId() == kDirectionUp);
     mod->setType(fType->currentData().toInt());
     mod->setLoops(fLoops->value());

--- a/src/PrpShop/PRP/Avatar/QMultistageBehMod.cpp
+++ b/src/PrpShop/PRP/Avatar/QMultistageBehMod.cpp
@@ -162,6 +162,19 @@ QMultistageBehMod::QMultistageBehMod(plCreatable* pCre, QWidget* parent)
     layFlags->addWidget(fSmartSeek, 1, 0);
     layFlags->addWidget(fReverseControls, 2, 0);
 
+    connect(fFreezePhys, &QCheckBox::clicked, this, [this](bool checked) {
+        plMultistageBehMod* obj = plMultistageBehMod::Convert(fCreatable);
+        obj->setFreezePhys(checked);
+    });
+    connect(fSmartSeek, &QCheckBox::clicked, this, [this](bool checked) {
+        plMultistageBehMod* obj = plMultistageBehMod::Convert(fCreatable);
+        obj->setSmartSeek(checked);
+    });
+    connect(fReverseControls, &QCheckBox::clicked, this, [this](bool checked) {
+        plMultistageBehMod* obj = plMultistageBehMod::Convert(fCreatable);
+        obj->setReverseFBControlsOnRelease(checked);
+    });
+
     QTabWidget* listTabs = new QTabWidget(this);
 
     fStages = new QTreeWidget(listTabs);
@@ -203,10 +216,6 @@ QMultistageBehMod::QMultistageBehMod(plCreatable* pCre, QWidget* parent)
 void QMultistageBehMod::saveDamage()
 {
     plMultistageBehMod* obj = plMultistageBehMod::Convert(fCreatable);
-
-    obj->setFreezePhys(fFreezePhys->isChecked());
-    obj->setSmartSeek(fSmartSeek->isChecked());
-    obj->setReverseFBControlsOnRelease(fReverseControls->isChecked());
 
     obj->clearReceivers();
     QList<plKey> keys = fReceivers->keys();

--- a/src/PrpShop/PRP/Avatar/QMultistageBehMod.h
+++ b/src/PrpShop/PRP/Avatar/QMultistageBehMod.h
@@ -20,9 +20,9 @@
 #include "PRP/QCreatable.h"
 
 #include <PRP/Avatar/plMultistageBehMod.h>
-#include <QCheckBox>
 #include <QComboBox>
 #include <QLineEdit>
+#include "QBitmaskCheckBox.h"
 #include "PRP/QObjLink.h"
 #include "PRP/QKeyList.h"
 
@@ -36,7 +36,7 @@ protected:
         kNotifyEnter, kNotifyLoop, kNotifyAdvance, kNotifyRegress,
         kNumNotifyFlags
     };
-    QCheckBox* fNotify[kNumNotifyFlags];
+    QBitmaskCheckBox* fNotify[kNumNotifyFlags];
 
     QComboBox* fForwardType;
     QComboBox* fBackType;

--- a/src/PrpShop/PRP/GUI/QGUICheckBoxCtrl.cpp
+++ b/src/PrpShop/PRP/GUI/QGUICheckBoxCtrl.cpp
@@ -35,6 +35,10 @@ QGUICheckBoxCtrl::QGUICheckBoxCtrl(plCreatable* pCre, QWidget* parent)
 
     fValue = new QCheckBox(tr("Checked"), this);
     fValue->setChecked(ctrl->isChecked());
+    connect(fValue, &QCheckBox::clicked, this, [this](bool checked) {
+        pfGUICheckBoxCtrl* ctrl = pfGUICheckBoxCtrl::Convert(fCreatable);
+        ctrl->setChecked(checked);
+    });
 
     QGridLayout* layout = new QGridLayout(this);
     layout->setContentsMargins(8, 8, 8, 8);
@@ -56,6 +60,4 @@ void QGUICheckBoxCtrl::saveDamage()
     QList<plKey> animKeys = fAnimationKeys->keys();
     while (!animKeys.isEmpty())
         ctrl->addAnimKey(animKeys.takeFirst());
-
-    ctrl->setChecked(fValue->isChecked());
 }

--- a/src/PrpShop/PRP/GUI/QGUIClickMapCtrl.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIClickMapCtrl.cpp
@@ -38,19 +38,16 @@ QGUIClickMapCtrl::QGUIClickMapCtrl(plCreatable* pCre, QWidget* parent)
     flagLayout->setHorizontalSpacing(8);
     flagLayout->addWidget(fModFlags[pfGUIClickMapCtrl::kReportDragging - kModFlagStart], 0, 0);
     flagLayout->addWidget(fModFlags[pfGUIClickMapCtrl::kReportHovering - kModFlagStart], 1, 0);
-    for (size_t i=0; i<kModFlagCount; i++)
+    for (size_t i = 0; i < kModFlagCount; ++i) {
         fModFlags[i]->setChecked(ctrl->getFlag(i + kModFlagStart));
+        connect(fModFlags[i], &QCheckBox::clicked, this, [this, i](bool checked) {
+            pfGUIClickMapCtrl* ctrl = pfGUIClickMapCtrl::Convert(fCreatable);
+            ctrl->setFlag(i + kModFlagStart, checked);
+        });
+    }
 
     QGridLayout* layout = new QGridLayout(this);
     layout->setContentsMargins(8, 8, 8, 8);
     layout->addWidget(fControlModLink, 0, 0, 1, 2);
     layout->addWidget(grpFlags, 1, 0, 1, 2);
-}
-
-void QGUIClickMapCtrl::saveDamage()
-{
-    pfGUIClickMapCtrl* ctrl = pfGUIClickMapCtrl::Convert(fCreatable);
-
-    for (size_t i=0; i<kModFlagCount; i++)
-        ctrl->setFlag(i + kModFlagStart, fModFlags[i]->isChecked());
 }

--- a/src/PrpShop/PRP/GUI/QGUIClickMapCtrl.h
+++ b/src/PrpShop/PRP/GUI/QGUIClickMapCtrl.h
@@ -40,7 +40,7 @@ protected:
 
 public:
     QGUIClickMapCtrl(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
+    void saveDamage() override { }
 };
 
 #endif

--- a/src/PrpShop/PRP/GUI/QGUIClickMapCtrl.h
+++ b/src/PrpShop/PRP/GUI/QGUIClickMapCtrl.h
@@ -40,7 +40,6 @@ protected:
 
 public:
     QGUIClickMapCtrl(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 };
 
 #endif

--- a/src/PrpShop/PRP/GUI/QGUIControlMod.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIControlMod.cpp
@@ -149,8 +149,14 @@ QGUIControlMod::QGUIControlMod(plCreatable* pCre, QWidget* parent)
     flagLayout->addWidget(fModFlags[pfGUIControlMod::kTakesSpecialKeys], 2, 1);
     flagLayout->addWidget(fModFlags[pfGUIControlMod::kHasProxy], 3, 0);
     flagLayout->addWidget(fModFlags[pfGUIControlMod::kBetterHitTesting], 3, 1);
-    for (size_t i=0; i<=pfGUIControlMod::kBetterHitTesting; i++)
+
+    for (size_t i = 0; i <= pfGUIControlMod::kBetterHitTesting; ++i) {
         fModFlags[i]->setChecked(ctrl->getFlag(i));
+        connect(fModFlags[i], &QCheckBox::clicked, this, [this, i](bool checked) {
+            pfGUIControlMod* ctrl = pfGUIControlMod::Convert(fCreatable);
+            ctrl->setFlag(i, checked);
+        });
+    }
 
     fColorSchemeGrp = new QGroupBox(tr("Color Scheme"), this);
     fColorScheme = new QGUIColorScheme(fColorSchemeGrp);
@@ -180,6 +186,11 @@ QGUIControlMod::QGUIControlMod(plCreatable* pCre, QWidget* parent)
     fTagID->setValue(ctrl->getTagID());
     fVisible = new QCheckBox(tr("Visible"), guiProcTab);
     fVisible->setChecked(ctrl->isVisible());
+
+    connect(fVisible, &QCheckBox::clicked, this, [this](bool checked) {
+        pfGUIControlMod* ctrl = pfGUIControlMod::Convert(fCreatable);
+        ctrl->setVisible(checked);
+    });
 
     fProcType = new QComboBox(guiProcTab);
     fProcType->addItems(QStringList() << "(NULL)" << tr("Console Command")
@@ -238,9 +249,6 @@ void QGUIControlMod::saveDamage()
 {
     pfGUIControlMod* ctrl = pfGUIControlMod::Convert(fCreatable);
 
-    for (size_t i=0; i<=pfGUIControlMod::kBetterHitTesting; i++)
-        ctrl->setFlag(i, fModFlags[i]->isChecked());
-
     if (fColorSchemeGrp->isChecked()) {
         if (ctrl->getColorScheme() == NULL)
             ctrl->setColorScheme(new pfGUIColorScheme());
@@ -250,7 +258,6 @@ void QGUIControlMod::saveDamage()
     }
 
     ctrl->setTagID(fTagID->value());
-    ctrl->setVisible(fVisible->isChecked());
 
     if (fProcType->currentIndex() == pfGUICtrlProcWriteableObject::kNull) {
         ctrl->setHandler(NULL);

--- a/src/PrpShop/PRP/GUI/QGUIControlMod.h
+++ b/src/PrpShop/PRP/GUI/QGUIControlMod.h
@@ -26,6 +26,7 @@
 #include "PRP/QObjLink.h"
 #include "PRP/QKeyList.h"
 #include "QColorEdit.h"
+#include "QBitmaskCheckBox.h"
 
 class QGUIColorScheme : public QWidget
 {
@@ -41,7 +42,8 @@ private:
     QLineEdit* fFontFace;
 
     enum { kCBBold, kCBItalic, kCBShadowed, kNumFontFlags };
-    QCheckBox* fFontFlags[kNumFontFlags];
+    QBitmaskCheckBox* fFontFlags[kNumFontFlags];
+    uint8_t fFontFlagsValue;
 
 public:
     QGUIColorScheme(QWidget* parent);

--- a/src/PrpShop/PRP/GUI/QGUIDialogMod.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIDialogMod.cpp
@@ -38,6 +38,11 @@ QGUIDialogMod::QGUIDialogMod(plCreatable* pCre, QWidget* parent)
     flagLayout->addWidget(fModFlagModal, 0, 0);
     fModFlagModal->setChecked(dlg->getFlag(pfGUIDialogMod::kModal));
 
+    connect(fModFlagModal, &QCheckBox::clicked, this, [this](bool checked) {
+        pfGUIDialogMod* dlg = pfGUIDialogMod::Convert(fCreatable);
+        dlg->setFlag(pfGUIDialogMod::kModal, checked);
+    });
+
     QGroupBox* colorSchemeGrp = new QGroupBox(tr("Color Scheme"), this);
     fColorScheme = new QGUIColorScheme(colorSchemeGrp);
     fColorScheme->setColorScheme(&dlg->getColorScheme());
@@ -101,7 +106,6 @@ void QGUIDialogMod::saveDamage()
 {
     pfGUIDialogMod* dlg = pfGUIDialogMod::Convert(fCreatable);
 
-    dlg->setFlag(pfGUIDialogMod::kModal, fModFlagModal->isChecked());
     fColorScheme->saveColorScheme(&dlg->getColorScheme());
     dlg->setName(fName->text().toUtf8().constData());
     dlg->setTagID(fTagID->value());

--- a/src/PrpShop/PRP/GUI/QGUIDraggableMod.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIDraggableMod.cpp
@@ -40,19 +40,17 @@ QGUIDraggableMod::QGUIDraggableMod(plCreatable* pCre, QWidget* parent)
     flagLayout->addWidget(fModFlags[pfGUIDraggableMod::kReportDragging - kModFlagStart], 0, 0);
     flagLayout->addWidget(fModFlags[pfGUIDraggableMod::kHideCursorWhileDragging - kModFlagStart], 1, 0);
     flagLayout->addWidget(fModFlags[pfGUIDraggableMod::kAlwaysSnapBackToStart - kModFlagStart], 2, 0);
-    for (size_t i=0; i<kModFlagCount; i++)
+
+    for (size_t i = 0; i < kModFlagCount; ++i) {
         fModFlags[i]->setChecked(ctrl->getFlag(i + kModFlagStart));
+        connect(fModFlags[i], &QCheckBox::clicked, this, [this, i](bool checked) {
+            pfGUIDraggableMod* ctrl = pfGUIDraggableMod::Convert(fCreatable);
+            ctrl->setFlag(i + kModFlagStart, checked);
+        });
+    }
 
     QGridLayout* layout = new QGridLayout(this);
     layout->setContentsMargins(8, 8, 8, 8);
     layout->addWidget(fControlModLink, 0, 0, 1, 2);
     layout->addWidget(grpFlags, 1, 0, 1, 2);
-}
-
-void QGUIDraggableMod::saveDamage()
-{
-    pfGUIDraggableMod* ctrl = pfGUIDraggableMod::Convert(fCreatable);
-
-    for (size_t i=0; i<kModFlagCount; i++)
-        ctrl->setFlag(i + kModFlagStart, fModFlags[i]->isChecked());
 }

--- a/src/PrpShop/PRP/GUI/QGUIDraggableMod.h
+++ b/src/PrpShop/PRP/GUI/QGUIDraggableMod.h
@@ -40,7 +40,6 @@ protected:
 
 public:
     QGUIDraggableMod(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 };
 
 #endif

--- a/src/PrpShop/PRP/GUI/QGUIDraggableMod.h
+++ b/src/PrpShop/PRP/GUI/QGUIDraggableMod.h
@@ -40,7 +40,7 @@ protected:
 
 public:
     QGUIDraggableMod(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
+    void saveDamage() override { }
 };
 
 #endif

--- a/src/PrpShop/PRP/GUI/QGUIKnobCtrl.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIKnobCtrl.cpp
@@ -44,8 +44,14 @@ QGUIKnobCtrl::QGUIKnobCtrl(plCreatable* pCre, QWidget* parent)
     flagLayout->addWidget(fModFlags[pfGUIKnobCtrl::kMapToScreenRange - kModFlagStart], 2, 0);
     flagLayout->addWidget(fModFlags[pfGUIKnobCtrl::kTriggerOnlyOnMouseUp - kModFlagStart], 3, 0);
     flagLayout->addWidget(fModFlags[pfGUIKnobCtrl::kMapToAnimationRange - kModFlagStart], 4, 0);
-    for (size_t i=0; i<kModFlagCount; i++)
+
+    for (size_t i = 0; i < kModFlagCount; ++i) {
         fModFlags[i]->setChecked(ctrl->getFlag(i + kModFlagStart));
+        connect(fModFlags[i], &QCheckBox::clicked, this, [this, i](bool checked) {
+            pfGUIKnobCtrl* ctrl = pfGUIKnobCtrl::Convert(fCreatable);
+            ctrl->setFlag(i + kModFlagStart, checked);
+        });
+    }
 
     fMin = new QFloatEdit(this);
     fMin->setRange(-2147483648.0, 2147483647.0, 3);
@@ -106,9 +112,6 @@ QGUIKnobCtrl::QGUIKnobCtrl(plCreatable* pCre, QWidget* parent)
 void QGUIKnobCtrl::saveDamage()
 {
     pfGUIKnobCtrl* ctrl = pfGUIKnobCtrl::Convert(fCreatable);
-
-    for (size_t i=0; i<kModFlagCount; i++)
-        ctrl->setFlag(i + kModFlagStart, fModFlags[i]->isChecked());
 
     ctrl->setRange(fMin->value(), fMax->value());
     ctrl->setStep(fStep->value());

--- a/src/PrpShop/PRP/GUI/QGUIListBoxMod.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIListBoxMod.cpp
@@ -56,8 +56,14 @@ QGUIListBoxMod::QGUIListBoxMod(plCreatable* pCre, QWidget* parent)
     flagLayout->addWidget(fModFlags[pfGUIListBoxMod::kGrowLeavesAndProcessOxygen - kModFlagStart], 2, 1);
     flagLayout->addWidget(fModFlags[pfGUIListBoxMod::kHandsOffMultiSelect - kModFlagStart], 3, 1);
     flagLayout->addWidget(fModFlags[pfGUIListBoxMod::kForbidNoSelection - kModFlagStart], 4, 1);
-    for (size_t i=0; i<kModFlagCount; i++)
+
+    for (size_t i = 0; i < kModFlagCount; ++i) {
         fModFlags[i]->setChecked(ctrl->getFlag(i + kModFlagStart));
+        connect(fModFlags[i], &QCheckBox::clicked, this, [this, i](bool checked) {
+            pfGUIListBoxMod* ctrl = pfGUIListBoxMod::Convert(fCreatable);
+            ctrl->setFlag(i + kModFlagStart, checked);
+        });
+    }
 
     fScrollCtrl = new QCreatableLink(this);
     fScrollCtrl->setKey(ctrl->getScrollCtrl());
@@ -71,14 +77,6 @@ QGUIListBoxMod::QGUIListBoxMod(plCreatable* pCre, QWidget* parent)
 
     connect(fScrollCtrl, SIGNAL(addObject()), this, SLOT(setScrollCtrl()));
     connect(fScrollCtrl, SIGNAL(delObject()), this, SLOT(unsetScrollCtrl()));
-}
-
-void QGUIListBoxMod::saveDamage()
-{
-    pfGUIListBoxMod* ctrl = pfGUIListBoxMod::Convert(fCreatable);
-
-    for (size_t i=0; i<kModFlagCount; i++)
-        ctrl->setFlag(i + kModFlagStart, fModFlags[i]->isChecked());
 }
 
 void QGUIListBoxMod::setScrollCtrl()

--- a/src/PrpShop/PRP/GUI/QGUIListBoxMod.h
+++ b/src/PrpShop/PRP/GUI/QGUIListBoxMod.h
@@ -41,7 +41,7 @@ protected:
 
 public:
     QGUIListBoxMod(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
+    void saveDamage() override { }
 
 private slots:
     void setScrollCtrl();

--- a/src/PrpShop/PRP/GUI/QGUIListBoxMod.h
+++ b/src/PrpShop/PRP/GUI/QGUIListBoxMod.h
@@ -41,7 +41,6 @@ protected:
 
 public:
     QGUIListBoxMod(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 
 private slots:
     void setScrollCtrl();

--- a/src/PrpShop/PRP/GUI/QGUIMenuItem.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIMenuItem.cpp
@@ -38,19 +38,17 @@ QGUIMenuItem::QGUIMenuItem(plCreatable* pCre, QWidget* parent)
     flagLayout->setHorizontalSpacing(8);
     flagLayout->addWidget(fModFlags[pfGUIMenuItem::kDrawSubMenuArrow - kModFlagStart], 0, 0);
     flagLayout->addWidget(fModFlags[pfGUIMenuItem::kReportHovers - kModFlagStart], 1, 0);
-    for (size_t i=0; i<kModFlagCount; i++)
+
+    for (size_t i = 0; i < kModFlagCount; ++i) {
         fModFlags[i]->setChecked(ctrl->getFlag(i + kModFlagStart));
+        connect(fModFlags[i], &QCheckBox::clicked, this, [this, i](bool checked) {
+            pfGUIMenuItem* ctrl = pfGUIMenuItem::Convert(fCreatable);
+            ctrl->setFlag(i + kModFlagStart, checked);
+        });
+    }
 
     QGridLayout* layout = new QGridLayout(this);
     layout->setContentsMargins(8, 8, 8, 8);
     layout->addWidget(fButtonModLink, 0, 0, 1, 2);
     layout->addWidget(grpFlags, 1, 0, 1, 2);
-}
-
-void QGUIMenuItem::saveDamage()
-{
-    pfGUIMenuItem* ctrl = pfGUIMenuItem::Convert(fCreatable);
-
-    for (size_t i=0; i<kModFlagCount; i++)
-        ctrl->setFlag(i + kModFlagStart, fModFlags[i]->isChecked());
 }

--- a/src/PrpShop/PRP/GUI/QGUIMenuItem.h
+++ b/src/PrpShop/PRP/GUI/QGUIMenuItem.h
@@ -40,7 +40,7 @@ protected:
 
 public:
     QGUIMenuItem(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
+    void saveDamage() override { }
 };
 
 #endif

--- a/src/PrpShop/PRP/GUI/QGUIMenuItem.h
+++ b/src/PrpShop/PRP/GUI/QGUIMenuItem.h
@@ -40,7 +40,6 @@ protected:
 
 public:
     QGUIMenuItem(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 };
 
 #endif

--- a/src/PrpShop/PRP/GUI/QGUIMultiLineEditCtrl.h
+++ b/src/PrpShop/PRP/GUI/QGUIMultiLineEditCtrl.h
@@ -32,7 +32,6 @@ protected:
 
 public:
     QGUIMultiLineEditCtrl(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 
 private slots:
     void setScrollCtrl();

--- a/src/PrpShop/PRP/GUI/QGUIPopUpMenu.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIPopUpMenu.cpp
@@ -116,8 +116,14 @@ QGUIPopUpMenu::QGUIPopUpMenu(plCreatable* pCre, QWidget* parent)
     flagLayout->addWidget(fModFlags[pfGUIPopUpMenu::kModalOutsideMenus - kModFlagStart], 1, 0);
     flagLayout->addWidget(fModFlags[pfGUIPopUpMenu::kOpenSubMenusOnHover - kModFlagStart], 2, 0);
     flagLayout->addWidget(fModFlags[pfGUIPopUpMenu::kScaleWithResolution - kModFlagStart], 3, 0);
-    for (size_t i=0; i<kModFlagCount; i++)
+
+    for (size_t i = 0; i < kModFlagCount; ++i) {
         fModFlags[i]->setChecked(ctrl->getFlag(i + kModFlagStart));
+        connect(fModFlags[i], &QCheckBox::clicked, this, [this, i](bool checked) {
+            pfGUIPopUpMenu* ctrl = pfGUIPopUpMenu::Convert(fCreatable);
+            ctrl->setFlag(i + kModFlagStart, checked);
+        });
+    }
 
     fAlignment = new QComboBox(this);
     fAlignment->addItems(QStringList() << tr("Upper Left") << tr("Upper Right")
@@ -173,9 +179,6 @@ QGUIPopUpMenu::QGUIPopUpMenu(plCreatable* pCre, QWidget* parent)
 void QGUIPopUpMenu::saveDamage()
 {
     pfGUIPopUpMenu* ctrl = pfGUIPopUpMenu::Convert(fCreatable);
-
-    for (size_t i=0; i<kModFlagCount; i++)
-        ctrl->setFlag(i + kModFlagStart, fModFlags[i]->isChecked());
 
     ctrl->setAlignment((pfGUIPopUpMenu::Alignment)fAlignment->currentIndex());
     ctrl->setMargin(fMargin->value());

--- a/src/PrpShop/PRP/GUI/QGUIProgressCtrl.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIProgressCtrl.cpp
@@ -44,8 +44,14 @@ QGUIProgressCtrl::QGUIProgressCtrl(plCreatable* pCre, QWidget* parent)
     flagLayout->addWidget(fModFlags[pfGUIProgressCtrl::kMapToScreenRange - kModFlagStart], 2, 0);
     flagLayout->addWidget(fModFlags[pfGUIProgressCtrl::kTriggerOnlyOnMouseUp - kModFlagStart], 3, 0);
     flagLayout->addWidget(fModFlags[pfGUIProgressCtrl::kMapToAnimationRange - kModFlagStart], 4, 0);
-    for (size_t i=0; i<kModFlagCount; i++)
+
+    for (size_t i = 0; i < kModFlagCount; ++i) {
         fModFlags[i]->setChecked(ctrl->getFlag(i + kModFlagStart));
+        connect(fModFlags[i], &QCheckBox::clicked, this, [this, i](bool checked) {
+            pfGUIProgressCtrl* ctrl = pfGUIProgressCtrl::Convert(fCreatable);
+            ctrl->setFlag(i + kModFlagStart, checked);
+        });
+    }
 
     fMin = new QFloatEdit(this);
     fMin->setRange(-2147483648.0, 2147483647.0, 3);
@@ -82,9 +88,6 @@ QGUIProgressCtrl::QGUIProgressCtrl(plCreatable* pCre, QWidget* parent)
 void QGUIProgressCtrl::saveDamage()
 {
     pfGUIProgressCtrl* ctrl = pfGUIProgressCtrl::Convert(fCreatable);
-
-    for (size_t i=0; i<kModFlagCount; i++)
-        ctrl->setFlag(i + kModFlagStart, fModFlags[i]->isChecked());
 
     ctrl->setRange(fMin->value(), fMax->value());
     ctrl->setStep(fStep->value());

--- a/src/PrpShop/PRP/GUI/QGUIRadioGroupCtrl.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIRadioGroupCtrl.cpp
@@ -38,6 +38,11 @@ QGUIRadioGroupCtrl::QGUIRadioGroupCtrl(plCreatable* pCre, QWidget* parent)
     flagLayout->addWidget(fModFlagAllowNoSelection, 0, 0);
     fModFlagAllowNoSelection->setChecked(ctrl->getFlag(pfGUIRadioGroupCtrl::kAllowNoSelection));
 
+    connect(fModFlagAllowNoSelection, &QCheckBox::clicked, this, [this](bool checked) {
+        pfGUIRadioGroupCtrl* ctrl = pfGUIRadioGroupCtrl::Convert(fCreatable);
+        ctrl->setFlag(pfGUIRadioGroupCtrl::kAllowNoSelection, checked);
+    });
+
     fControls = new QKeyList(ctrl->getKey(), this);
     fDefaultValue = new QComboBox(this);
     for (size_t i=0; i<ctrl->getControls().size(); i++) {
@@ -65,9 +70,6 @@ QGUIRadioGroupCtrl::QGUIRadioGroupCtrl(plCreatable* pCre, QWidget* parent)
 void QGUIRadioGroupCtrl::saveDamage()
 {
     pfGUIRadioGroupCtrl* ctrl = pfGUIRadioGroupCtrl::Convert(fCreatable);
-
-    ctrl->setFlag(pfGUIRadioGroupCtrl::kAllowNoSelection,
-                  fModFlagAllowNoSelection->isChecked());
 
     ctrl->clearControls();
     QList<plKey> ctrlKeys = fControls->keys();

--- a/src/PrpShop/PRP/GUI/QGUITextBoxMod.cpp
+++ b/src/PrpShop/PRP/GUI/QGUITextBoxMod.cpp
@@ -57,8 +57,14 @@ QGUITextBoxMod::QGUITextBoxMod(plCreatable* pCre, QWidget* parent)
     flagLayout->setHorizontalSpacing(8);
     flagLayout->addWidget(fModFlags[pfGUITextBoxMod::kCenterJustify - kModFlagStart], 0, 0);
     flagLayout->addWidget(fModFlags[pfGUITextBoxMod::kRightJustify - kModFlagStart], 1, 0);
-    for (size_t i=0; i<kModFlagCount; i++)
+
+    for (size_t i = 0; i < kModFlagCount; ++i) {
         fModFlags[i]->setChecked(ctrl->getFlag(i + kModFlagStart));
+        connect(fModFlags[i], &QCheckBox::clicked, this, [this, i](bool checked) {
+            pfGUITextBoxMod* ctrl = pfGUITextBoxMod::Convert(fCreatable);
+            ctrl->setFlag(i + kModFlagStart, checked);
+        });
+    }
 
     fText = new QSmallTextEdit(this);
     fText->setPlainText(st2qstr(ctrl->getText()));
@@ -78,9 +84,6 @@ QGUITextBoxMod::QGUITextBoxMod(plCreatable* pCre, QWidget* parent)
 void QGUITextBoxMod::saveDamage()
 {
     pfGUITextBoxMod* ctrl = pfGUITextBoxMod::Convert(fCreatable);
-
-    for (size_t i=0; i<kModFlagCount; i++)
-        ctrl->setFlag(i + kModFlagStart, fModFlags[i]->isChecked());
 
     ctrl->setText(qstr2st(fText->toPlainText()));
     ctrl->setLocalizationPath(qstr2st(fLocalizationPath->text()));

--- a/src/PrpShop/PRP/Light/QShadowMaster.cpp
+++ b/src/PrpShop/PRP/Light/QShadowMaster.cpp
@@ -43,8 +43,14 @@ QShadowMaster::QShadowMaster(plCreatable* pCre, QWidget* parent)
     fProperties[plShadowMaster::kSelfShadow] = new QCheckBox(tr("Self Shadow"), grpProps);
     layProps->addWidget(fProperties[plShadowMaster::kDisable], 0, 0);
     layProps->addWidget(fProperties[plShadowMaster::kSelfShadow], 0, 1);
-    for (size_t i=0; i<plShadowMaster::kNumProps; i++)
+
+    for (size_t i = 0; i < plShadowMaster::kNumProps; ++i) {
         fProperties[i]->setChecked(obj->getProperty(i));
+        connect(fProperties[i], &QCheckBox::clicked, this, [this, i](bool checked) {
+            plShadowMaster* obj = plShadowMaster::Convert(fCreatable);
+            obj->setProperty(i, checked);
+        });
+    }
 
     fMinDist = new QFloatEdit(this);
     fMinDist->setValue(obj->getMinDist());
@@ -92,8 +98,6 @@ void QShadowMaster::saveDamage()
 {
     plShadowMaster* obj = plShadowMaster::Convert(fCreatable);
 
-    for (size_t i=0; i<plShadowMaster::kNumProps; i++)
-        obj->setProperty(i, fProperties[i]->isChecked());
     obj->setAttenDist(fAttenDist->value());
     obj->setDist(fMinDist->value(), fMaxDist->value());
     obj->setSize(fMinSize->value(), fMaxSize->value());

--- a/src/PrpShop/PRP/Modifier/QOneShotMod.cpp
+++ b/src/PrpShop/PRP/Modifier/QOneShotMod.cpp
@@ -47,6 +47,23 @@ QOneShotMod::QOneShotMod(plCreatable* pCre, QWidget* parent)
     layFlags->addWidget(fSmartSeek, 0, 1);
     layFlags->addWidget(fNoSeek, 1, 1);
 
+    connect(fDrivable, &QCheckBox::clicked, this, [this](bool checked) {
+        plOneShotMod* obj = plOneShotMod::Convert(fCreatable);
+        obj->setDrivable(checked);
+    });
+    connect(fReversable, &QCheckBox::clicked, this, [this](bool checked) {
+        plOneShotMod* obj = plOneShotMod::Convert(fCreatable);
+        obj->setReversable(checked);
+    });
+    connect(fSmartSeek, &QCheckBox::clicked, this, [this](bool checked) {
+        plOneShotMod* obj = plOneShotMod::Convert(fCreatable);
+        obj->setSmartSeek(checked);
+    });
+    connect(fNoSeek, &QCheckBox::clicked, this, [this](bool checked) {
+        plOneShotMod* obj = plOneShotMod::Convert(fCreatable);
+        obj->setNoSeek(checked);
+    });
+
     fAnimName = new QLineEdit(this);
     fAnimName->setText(st2qstr(obj->getAnimName()));
     fSeekDuration = new QFloatEdit(this);
@@ -65,11 +82,6 @@ QOneShotMod::QOneShotMod(plCreatable* pCre, QWidget* parent)
 void QOneShotMod::saveDamage()
 {
     plOneShotMod* obj = plOneShotMod::Convert(fCreatable);
-
-    obj->setDrivable(fDrivable->isChecked());
-    obj->setReversable(fReversable->isChecked());
-    obj->setSmartSeek(fSmartSeek->isChecked());
-    obj->setNoSeek(fNoSeek->isChecked());
 
     obj->setAnimName(qstr2st(fAnimName->text()));
     obj->setSeekDuration(fSeekDuration->value());

--- a/src/PrpShop/PRP/Modifier/QSpawnModifier.h
+++ b/src/PrpShop/PRP/Modifier/QSpawnModifier.h
@@ -29,7 +29,6 @@ protected:
 
 public:
     QSpawnModifier(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 };
 
 #endif

--- a/src/PrpShop/PRP/Object/QAudioInterface.cpp
+++ b/src/PrpShop/PRP/Object/QAudioInterface.cpp
@@ -42,6 +42,11 @@ QAudioInterface::QAudioInterface(plCreatable* pCre, QWidget* parent)
     layProps->addWidget(fDisabled, 0, 0);
     fDisabled->setChecked(intf->getProperty(plAudioInterface::kDisable));
 
+    connect(fDisabled, &QCheckBox::clicked, this, [this](bool checked) {
+        plAudioInterface* intf = plAudioInterface::Convert(fCreatable);
+        intf->setProperty(plAudioInterface::kDisable, checked);
+    });
+
     fAudibleLink = new QCreatableLink(this);
     fAudibleLink->setKey(intf->getAudible());
 
@@ -57,12 +62,6 @@ QAudioInterface::QAudioInterface(plCreatable* pCre, QWidget* parent)
     connect(fOwnerLink, SIGNAL(delObject()), this, SLOT(unsetOwner()));
     connect(fAudibleLink, SIGNAL(addObject()), this, SLOT(setAudible()));
     connect(fAudibleLink, SIGNAL(delObject()), this, SLOT(unsetAudible()));
-}
-
-void QAudioInterface::saveDamage()
-{
-    plAudioInterface* intf = plAudioInterface::Convert(fCreatable);
-    intf->setProperty(plAudioInterface::kDisable, fDisabled->isChecked());
 }
 
 void QAudioInterface::setOwner()

--- a/src/PrpShop/PRP/Object/QAudioInterface.h
+++ b/src/PrpShop/PRP/Object/QAudioInterface.h
@@ -35,7 +35,6 @@ protected:
 
 public:
     QAudioInterface(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 
 protected slots:
     void setOwner();

--- a/src/PrpShop/PRP/Object/QAudioInterface.h
+++ b/src/PrpShop/PRP/Object/QAudioInterface.h
@@ -35,7 +35,7 @@ protected:
 
 public:
     QAudioInterface(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
+    void saveDamage() override { }
 
 protected slots:
     void setOwner();

--- a/src/PrpShop/PRP/Object/QCoordinateInterface.cpp
+++ b/src/PrpShop/PRP/Object/QCoordinateInterface.cpp
@@ -49,8 +49,14 @@ QCoordinateInterface::QCoordinateInterface(plCreatable* pCre, QWidget* parent)
     layProps->addWidget(fCBProperties[plCoordinateInterface::kDisable], 0, 0);
     layProps->addWidget(fCBProperties[plCoordinateInterface::kCanEverDelayTransform], 1, 0);
     layProps->addWidget(fCBProperties[plCoordinateInterface::kDelayedTransformEval], 2, 0);
-    for (size_t i=0; i<plCoordinateInterface::kNumProps; i++)
-        fCBProperties[i]->setChecked(intf->getProperty(i));
+
+    for (size_t prop = 0; prop < plCoordinateInterface::kNumProps; ++prop) {
+        fCBProperties[prop]->setChecked(intf->getProperty(prop));
+        connect(fCBProperties[prop], &QCheckBox::clicked, this, [this, prop](bool checked) {
+            plCoordinateInterface* intf = plCoordinateInterface::Convert(fCreatable);
+            intf->setProperty(prop, checked);
+        });
+    }
 
     QTabWidget* xformTab = new QTabWidget(this);
     fLocalToParent = new QMatrix44(xformTab);
@@ -89,9 +95,6 @@ QCoordinateInterface::QCoordinateInterface(plCreatable* pCre, QWidget* parent)
 void QCoordinateInterface::saveDamage()
 {
     plCoordinateInterface* intf = plCoordinateInterface::Convert(fCreatable);
-
-    for (size_t i=0; i<plCoordinateInterface::kNumProps; i++)
-        intf->setProperty(i, fCBProperties[i]->isChecked());
 
     intf->setLocalToParent(fLocalToParent->value());
     intf->setParentToLocal(fParentToLocal->value());

--- a/src/PrpShop/PRP/Object/QDrawInterface.cpp
+++ b/src/PrpShop/PRP/Object/QDrawInterface.cpp
@@ -140,6 +140,11 @@ QDrawInterface::QDrawInterface(plCreatable* pCre, QWidget* parent)
     layProps->addWidget(fDisabled, 0, 0);
     fDisabled->setChecked(intf->getProperty(plDrawInterface::kDisable));
 
+    connect(fDisabled, &QCheckBox::clicked, this, [this](bool checked) {
+        plDrawInterface* intf = plDrawInterface::Convert(fCreatable);
+        intf->setProperty(plDrawInterface::kDisable, checked);
+    });
+
     QTabWidget* childTab = new QTabWidget(this);
 
     fDrawKeys = new QDrawableList(intf->getKey(), childTab);
@@ -169,7 +174,6 @@ QDrawInterface::QDrawInterface(plCreatable* pCre, QWidget* parent)
 void QDrawInterface::saveDamage()
 {
     plDrawInterface* intf = plDrawInterface::Convert(fCreatable);
-    intf->setProperty(plDrawInterface::kDisable, fDisabled->isChecked());
 
     intf->clearDrawables();
     QList<plKey> drawables = fDrawKeys->keys();

--- a/src/PrpShop/PRP/Object/QSimulationInterface.cpp
+++ b/src/PrpShop/PRP/Object/QSimulationInterface.cpp
@@ -66,8 +66,14 @@ QSimulationInterface::QSimulationInterface(plCreatable* pCre, QWidget* parent)
     layProps->addWidget(fCBProperties[plSimulationInterface::kNoOwnershipChange], 5, 1);
     layProps->addWidget(fCBProperties[plSimulationInterface::kSuppressed], 6, 0);
     layProps->addWidget(fCBProperties[plSimulationInterface::kAvAnimPushable], 6, 1);
-    for (size_t i=0; i<plSimulationInterface::kNumProps; i++)
-        fCBProperties[i]->setChecked(intf->getProperty(i));
+
+    for (size_t prop = 0; prop < plSimulationInterface::kNumProps; ++prop) {
+        fCBProperties[prop]->setChecked(intf->getProperty(prop));
+        connect(fCBProperties[prop], &QCheckBox::clicked, this, [this, prop](bool checked) {
+            plSimulationInterface* intf = plSimulationInterface::Convert(fCreatable);
+            intf->setProperty(prop, checked);
+        });
+    }
 
     fPhysicalLink = new QCreatableLink(this);
     fPhysicalLink->setKey(intf->getPhysical());
@@ -84,13 +90,6 @@ QSimulationInterface::QSimulationInterface(plCreatable* pCre, QWidget* parent)
     connect(fOwnerLink, SIGNAL(delObject()), this, SLOT(unsetOwner()));
     connect(fPhysicalLink, SIGNAL(addObject()), this, SLOT(setPhysical()));
     connect(fPhysicalLink, SIGNAL(delObject()), this, SLOT(unsetPhysical()));
-}
-
-void QSimulationInterface::saveDamage()
-{
-    plSimulationInterface* intf = plSimulationInterface::Convert(fCreatable);
-    for (size_t i=0; i<plSimulationInterface::kNumProps; i++)
-        intf->setProperty(i, fCBProperties[i]->isChecked());
 }
 
 void QSimulationInterface::setOwner()

--- a/src/PrpShop/PRP/Object/QSimulationInterface.h
+++ b/src/PrpShop/PRP/Object/QSimulationInterface.h
@@ -35,7 +35,7 @@ protected:
 
 public:
     QSimulationInterface(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
+    void saveDamage() override { }
 
 protected slots:
     void setOwner();

--- a/src/PrpShop/PRP/Object/QSimulationInterface.h
+++ b/src/PrpShop/PRP/Object/QSimulationInterface.h
@@ -35,7 +35,6 @@ protected:
 
 public:
     QSimulationInterface(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 
 protected slots:
     void setOwner();

--- a/src/PrpShop/PRP/Object/QSynchedObject.cpp
+++ b/src/PrpShop/PRP/Object/QSynchedObject.cpp
@@ -31,14 +31,22 @@ QSynchedObject::QSynchedObject(plCreatable* pCre, QWidget* parent)
     QGridLayout* layFlags = new QGridLayout(grpFlags);
     layFlags->setVerticalSpacing(0);
     layFlags->setHorizontalSpacing(8);
-    fCBFlags[kCbDontDirty] = new QCheckBox(tr("Don't Dirty"), grpFlags);
-    fCBFlags[kCbSendReliably] = new QCheckBox(tr("Send Reliably"), grpFlags);
-    fCBFlags[kCbHasConstantNetGroup] = new QCheckBox(tr("Has Constant Net Group"), grpFlags);
-    fCBFlags[kCbDontSynchGameMessages] = new QCheckBox(tr("Don't Synch Game Messages"), grpFlags);
-    fCBFlags[kCbExcludePersistentState] = new QCheckBox(tr("Exclude Persistent States"), grpFlags);
-    fCBFlags[kCbExcludeAllPersistentState] = new QCheckBox(tr("Exclude All Persistent States"), grpFlags);
-    fCBFlags[kCbHasVolatileState] = new QCheckBox(tr("Has Volatile States"), grpFlags);
-    fCBFlags[kCbAllStateIsVolatile] = new QCheckBox(tr("All States Volatile"), grpFlags);
+    fCBFlags[kCbDontDirty] = new QBitmaskCheckBox(plSynchedObject::kDontDirty,
+            tr("Don't Dirty"), grpFlags);
+    fCBFlags[kCbSendReliably] = new QBitmaskCheckBox(plSynchedObject::kSendReliably,
+            tr("Send Reliably"), grpFlags);
+    fCBFlags[kCbHasConstantNetGroup] = new QBitmaskCheckBox(plSynchedObject::kHasConstantNetGroup,
+            tr("Has Constant Net Group"), grpFlags);
+    fCBFlags[kCbDontSynchGameMessages] = new QBitmaskCheckBox(plSynchedObject::kDontSynchGameMessages,
+            tr("Don't Synch Game Messages"), grpFlags);
+    fCBFlags[kCbExcludePersistentState] = new QBitmaskCheckBox(plSynchedObject::kExcludePersistentState,
+            tr("Exclude Persistent States"), grpFlags);
+    fCBFlags[kCbExcludeAllPersistentState] = new QBitmaskCheckBox(plSynchedObject::kExcludeAllPersistentState,
+            tr("Exclude All Persistent States"), grpFlags);
+    fCBFlags[kCbHasVolatileState] = new QBitmaskCheckBox(plSynchedObject::kHasVolatileState,
+            tr("Has Volatile States"), grpFlags);
+    fCBFlags[kCbAllStateIsVolatile] = new QBitmaskCheckBox(plSynchedObject::kAllStateIsVolatile,
+            tr("All States Volatile"), grpFlags);
     layFlags->addWidget(fCBFlags[kCbDontDirty], 0, 0);
     layFlags->addWidget(fCBFlags[kCbDontSynchGameMessages], 0, 1);
     layFlags->addWidget(fCBFlags[kCbSendReliably], 1, 0);
@@ -47,14 +55,17 @@ QSynchedObject::QSynchedObject(plCreatable* pCre, QWidget* parent)
     layFlags->addWidget(fCBFlags[kCbExcludePersistentState], 2, 1);
     layFlags->addWidget(fCBFlags[kCbAllStateIsVolatile], 3, 0);
     layFlags->addWidget(fCBFlags[kCbExcludeAllPersistentState], 3, 1);
-    fCBFlags[kCbDontDirty]->setChecked((obj->getSynchFlags() & plSynchedObject::kDontDirty) != 0);
-    fCBFlags[kCbSendReliably]->setChecked((obj->getSynchFlags() & plSynchedObject::kSendReliably) != 0);
-    fCBFlags[kCbHasConstantNetGroup]->setChecked((obj->getSynchFlags() & plSynchedObject::kHasConstantNetGroup) != 0);
-    fCBFlags[kCbDontSynchGameMessages]->setChecked((obj->getSynchFlags() & plSynchedObject::kDontSynchGameMessages) != 0);
-    fCBFlags[kCbExcludePersistentState]->setChecked((obj->getSynchFlags() & plSynchedObject::kExcludePersistentState) != 0);
-    fCBFlags[kCbExcludeAllPersistentState]->setChecked((obj->getSynchFlags() & plSynchedObject::kExcludeAllPersistentState) != 0);
-    fCBFlags[kCbHasVolatileState]->setChecked((obj->getSynchFlags() & plSynchedObject::kHasVolatileState) != 0);
-    fCBFlags[kCbAllStateIsVolatile]->setChecked((obj->getSynchFlags() & plSynchedObject::kAllStateIsVolatile) != 0);
+    for (auto cb : fCBFlags) {
+        cb->setFrom(obj->getSynchFlags());
+        connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            plSynchedObject* obj = plSynchedObject::Convert(fCreatable);
+            obj->setSynchFlags(obj->getSynchFlags() | mask);
+        });
+        connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            plSynchedObject* obj = plSynchedObject::Convert(fCreatable);
+            obj->setSynchFlags(obj->getSynchFlags() & ~mask);
+        });
+    }
 
     QTabWidget* sdlTab = new QTabWidget(this);
     fExcludeList = new QStringListWidget(sdlTab);
@@ -77,14 +88,6 @@ void QSynchedObject::saveDamage()
 {
     plSynchedObject* obj = plSynchedObject::Convert(fCreatable);
 
-    obj->setSynchFlags((fCBFlags[kCbDontDirty]->isChecked() ? plSynchedObject::kDontDirty : 0)
-                     | (fCBFlags[kCbSendReliably]->isChecked() ? plSynchedObject::kSendReliably : 0)
-                     | (fCBFlags[kCbHasConstantNetGroup]->isChecked() ? plSynchedObject::kHasConstantNetGroup : 0)
-                     | (fCBFlags[kCbDontSynchGameMessages]->isChecked() ? plSynchedObject::kDontSynchGameMessages : 0)
-                     | (fCBFlags[kCbExcludePersistentState]->isChecked() ? plSynchedObject::kExcludePersistentState : 0)
-                     | (fCBFlags[kCbExcludeAllPersistentState]->isChecked() ? plSynchedObject::kExcludeAllPersistentState : 0)
-                     | (fCBFlags[kCbHasVolatileState]->isChecked() ? plSynchedObject::kHasVolatileState : 0)
-                     | (fCBFlags[kCbAllStateIsVolatile]->isChecked() ? plSynchedObject::kAllStateIsVolatile : 0));
     obj->clearExcludes();
     obj->clearVolatiles();
     QStringList excludes = fExcludeList->strings();

--- a/src/PrpShop/PRP/Object/QSynchedObject.h
+++ b/src/PrpShop/PRP/Object/QSynchedObject.h
@@ -20,7 +20,7 @@
 #include "PRP/QCreatable.h"
 
 #include <PRP/Object/plCoordinateInterface.h>
-#include <QCheckBox>
+#include "QBitmaskCheckBox.h"
 #include "PRP/QKeyList.h"
 
 class QSynchedObject : public QCreatable
@@ -36,7 +36,7 @@ protected:
         kCbAllStateIsVolatile, kNumCbFlags
     };
 
-    QCheckBox* fCBFlags[kNumCbFlags];
+    QBitmaskCheckBox* fCBFlags[kNumCbFlags];
     QStringListWidget* fExcludeList;
     QStringListWidget* fVolatileList;
 

--- a/src/PrpShop/PRP/Physics/QCollisionDetector.cpp
+++ b/src/PrpShop/PRP/Physics/QCollisionDetector.cpp
@@ -82,6 +82,11 @@ QCollisionDetector::QCollisionDetector(plCreatable* pCre, QWidget* parent)
         fBoolParam = new QCheckBox(tr("On Exit"), this);
         fBoolParam->setChecked(subDet->getOnExit());
 
+        connect(fBoolParam, &QCheckBox::clicked, this, [this](bool checked) {
+            plSubworldRegionDetector* subDet = plSubworldRegionDetector::Convert(fCreatable);
+            subDet->setOnExit(checked);
+        });
+
         layout->addWidget(new QLabel(tr("Subworld:"), this), 1, 0, 1, 1);
         layout->addWidget(fSubworld, 1, 1, 1, 1);
         layout->addWidget(fBoolParam, 2, 0, 1, 2);
@@ -95,21 +100,11 @@ QCollisionDetector::QCollisionDetector(plCreatable* pCre, QWidget* parent)
         fBoolParam = new QCheckBox(tr("Play Link-Out Animation"), this);
         fBoolParam->setChecked(plRgn->getPlayLinkOutAnim());
         layout->addWidget(fBoolParam, 2, 0, 1, 2);
-    }
-}
 
-void QCollisionDetector::saveDamage()
-{
-    plCollisionDetector* obj = plCollisionDetector::Convert(fCreatable);
-
-    if (obj->ClassInstance(kSubworldRegionDetector)) {
-        plSubworldRegionDetector* subDet = plSubworldRegionDetector::Convert(fCreatable);
-        subDet->setOnExit(fBoolParam->isChecked());
-    }
-
-    if (obj->ClassInstance(kPanicLinkRegion)) {
-        plPanicLinkRegion* plRgn = plPanicLinkRegion::Convert(fCreatable);
-        plRgn->setPlayLinkOutAnim(fBoolParam->isChecked());
+        connect(fBoolParam, &QCheckBox::clicked, this, [this](bool checked) {
+            plPanicLinkRegion* plRgn = plPanicLinkRegion::Convert(fCreatable);
+            plRgn->setPlayLinkOutAnim(checked);
+        });
     }
 }
 

--- a/src/PrpShop/PRP/Physics/QCollisionDetector.cpp
+++ b/src/PrpShop/PRP/Physics/QCollisionDetector.cpp
@@ -41,25 +41,37 @@ QCollisionDetector::QCollisionDetector(plCreatable* pCre, QWidget* parent)
         QGridLayout* layType = new QGridLayout(grpType);
         layType->setVerticalSpacing(0);
         layType->setHorizontalSpacing(8);
-        fTypeFlags[kCBTypeEnter] = new QCheckBox(tr("Enter"), grpType);
-        fTypeFlags[kCBTypeExit] = new QCheckBox(tr("Exit"), grpType);
-        fTypeFlags[kCBTypeAny] = new QCheckBox(tr("Any"), grpType);
-        fTypeFlags[kCBTypeUnEnter] = new QCheckBox(tr("Un-Enter"), grpType);
-        fTypeFlags[kCBTypeUnExit] = new QCheckBox(tr("Un-Exit"), grpType);
-        fTypeFlags[kCBTypeBump] = new QCheckBox(tr("Bump"), grpType);
+        fTypeFlags[kCBTypeEnter] = new QBitmaskCheckBox(plCollisionDetector::kTypeEnter,
+                                                        tr("Enter"), grpType);
+        fTypeFlags[kCBTypeExit] = new QBitmaskCheckBox(plCollisionDetector::kTypeExit,
+                                                       tr("Exit"), grpType);
+        fTypeFlags[kCBTypeAny] = new QBitmaskCheckBox(plCollisionDetector::kTypeAny,
+                                                      tr("Any"), grpType);
+        fTypeFlags[kCBTypeUnEnter] = new QBitmaskCheckBox(plCollisionDetector::kTypeUnEnter,
+                                                          tr("Un-Enter"), grpType);
+        fTypeFlags[kCBTypeUnExit] = new QBitmaskCheckBox(plCollisionDetector::kTypeUnExit,
+                                                         tr("Un-Exit"), grpType);
+        fTypeFlags[kCBTypeBump] = new QBitmaskCheckBox(plCollisionDetector::kTypeBump,
+                                                       tr("Bump"), grpType);
         layType->addWidget(fTypeFlags[kCBTypeEnter], 0, 0);
         layType->addWidget(fTypeFlags[kCBTypeExit], 0, 1);
         layType->addWidget(fTypeFlags[kCBTypeAny], 0, 2);
         layType->addWidget(fTypeFlags[kCBTypeUnEnter], 1, 0);
         layType->addWidget(fTypeFlags[kCBTypeUnExit], 1, 1);
         layType->addWidget(fTypeFlags[kCBTypeBump], 1, 2);
-        fTypeFlags[kCBTypeEnter]->setChecked(obj->getType() & plCollisionDetector::kTypeEnter);
-        fTypeFlags[kCBTypeExit]->setChecked(obj->getType() & plCollisionDetector::kTypeExit);
-        fTypeFlags[kCBTypeAny]->setChecked(obj->getType() & plCollisionDetector::kTypeAny);
-        fTypeFlags[kCBTypeUnEnter]->setChecked(obj->getType() & plCollisionDetector::kTypeUnEnter);
-        fTypeFlags[kCBTypeUnExit]->setChecked(obj->getType() & plCollisionDetector::kTypeUnExit);
-        fTypeFlags[kCBTypeBump]->setChecked(obj->getType() & plCollisionDetector::kTypeBump);
         layout->addWidget(grpType, 1, 0, 1, 2);
+
+        for (auto cb : fTypeFlags) {
+            cb->setFrom(obj->getType());
+            connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+                plCollisionDetector* obj = plCollisionDetector::Convert(fCreatable);
+                obj->setType(obj->getType() | mask);
+            });
+            connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+                plCollisionDetector* obj = plCollisionDetector::Convert(fCreatable);
+                obj->setType(obj->getType() & ~mask);
+            });
+        }
     }
 
     if (obj->ClassInstance(kSubworldRegionDetector)) {
@@ -89,14 +101,6 @@ QCollisionDetector::QCollisionDetector(plCreatable* pCre, QWidget* parent)
 void QCollisionDetector::saveDamage()
 {
     plCollisionDetector* obj = plCollisionDetector::Convert(fCreatable);
-
-    if (!obj->ClassInstance(kSubworldRegionDetector))
-        obj->setType((fTypeFlags[kCBTypeEnter]->isChecked() ? plCollisionDetector::kTypeEnter : 0)
-                   | (fTypeFlags[kCBTypeExit]->isChecked() ? plCollisionDetector::kTypeExit : 0)
-                   | (fTypeFlags[kCBTypeAny]->isChecked() ? plCollisionDetector::kTypeAny : 0)
-                   | (fTypeFlags[kCBTypeUnEnter]->isChecked() ? plCollisionDetector::kTypeUnEnter : 0)
-                   | (fTypeFlags[kCBTypeUnExit]->isChecked() ? plCollisionDetector::kTypeUnExit : 0)
-                   | (fTypeFlags[kCBTypeBump]->isChecked() ? plCollisionDetector::kTypeBump : 0));
 
     if (obj->ClassInstance(kSubworldRegionDetector)) {
         plSubworldRegionDetector* subDet = plSubworldRegionDetector::Convert(fCreatable);

--- a/src/PrpShop/PRP/Physics/QCollisionDetector.h
+++ b/src/PrpShop/PRP/Physics/QCollisionDetector.h
@@ -41,7 +41,6 @@ protected:
 
 public:
     QCollisionDetector(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 
 protected slots:
     void setSubworld();

--- a/src/PrpShop/PRP/Physics/QCollisionDetector.h
+++ b/src/PrpShop/PRP/Physics/QCollisionDetector.h
@@ -20,8 +20,8 @@
 #include "PRP/QCreatable.h"
 
 #include <PRP/Physics/plCollisionDetector.h>
-#include <QCheckBox>
 #include "PRP/QObjLink.h"
+#include "QBitmaskCheckBox.h"
 
 class QCollisionDetector : public QCreatable
 {
@@ -37,7 +37,7 @@ protected:
         kCBTypeEnter, kCBTypeExit, kCBTypeAny, kCBTypeUnEnter, kCBTypeUnExit,
         kCBTypeBump, kNumTypeFlags
     };
-    QCheckBox* fTypeFlags[kNumTypeFlags];
+    QBitmaskCheckBox* fTypeFlags[kNumTypeFlags];
 
 public:
     QCollisionDetector(plCreatable* pCre, QWidget* parent = NULL);

--- a/src/PrpShop/PRP/Physics/QCollisionDetector.h
+++ b/src/PrpShop/PRP/Physics/QCollisionDetector.h
@@ -41,7 +41,7 @@ protected:
 
 public:
     QCollisionDetector(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
+    void saveDamage() override { }
 
 protected slots:
     void setSubworld();

--- a/src/PrpShop/PRP/QCreatable.h
+++ b/src/PrpShop/PRP/QCreatable.h
@@ -33,7 +33,7 @@ public:
     QCreatable(plCreatable* pCre, int type, QWidget* parent = NULL);
     bool isMatch(plCreatable* pCre, int type);
     bool compareLocation(const plLocation& loc);
-    virtual void saveDamage() = 0;
+    virtual void saveDamage() { }
 
 protected:
     void closeEvent(QCloseEvent* evt) override;

--- a/src/PrpShop/PRP/Render/QSceneObj_Preview.h
+++ b/src/PrpShop/PRP/Render/QSceneObj_Preview.h
@@ -29,7 +29,6 @@ protected:
 
 public:
     QSceneObj_Preview(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 };
 
 #endif

--- a/src/PrpShop/PRP/Surface/QCubicEnvironmap.cpp
+++ b/src/PrpShop/PRP/Surface/QCubicEnvironmap.cpp
@@ -31,22 +31,38 @@ QCubicEnvironmap::QCubicEnvironmap(plCreatable* pCre, QWidget* parent)
     QGridLayout* layFlags = new QGridLayout(grpFlags);
     layFlags->setVerticalSpacing(0);
     layFlags->setHorizontalSpacing(8);
-    fFlags[kAlphaChannelFlag] = new QCheckBox(tr("Alpha Channel"), grpFlags);
-    fFlags[kAlphaBitFlag] = new QCheckBox(tr("Alpha Bit"), grpFlags);
-    fFlags[kBumpEnvMap] = new QCheckBox(tr("Bump Env Map"), grpFlags);
-    fFlags[kForce32Bit] = new QCheckBox(tr("Force 32-bit"), grpFlags);
-    fFlags[kDontThrowAwayImage] = new QCheckBox(tr("Don't Throw Away"), grpFlags);
-    fFlags[kForceOneMipLevel] = new QCheckBox(tr("Force One Level"), grpFlags);
-    fFlags[kNoMaxSize] = new QCheckBox(tr("No Maximum Size"), grpFlags);
-    fFlags[kIntensityMap] = new QCheckBox(tr("Intensity Map"), grpFlags);
-    fFlags[kHalfSize] = new QCheckBox(tr("Half Size"), grpFlags);
-    fFlags[kUserOwnsBitmap] = new QCheckBox(tr("User Owned"), grpFlags);
-    fFlags[kForceRewrite] = new QCheckBox(tr("Force Rewrite"), grpFlags);
-    fFlags[kForceNonCompressed] = new QCheckBox(tr("Force Non-compressed"), grpFlags);
-    fFlags[kIsTexture] = new QCheckBox(tr("Is Texture"), grpFlags);
-    fFlags[kIsOffscreen] = new QCheckBox(tr("Is Offscreen"), grpFlags);
-    fFlags[kIsProjected] = new QCheckBox(tr("Is Projected"), grpFlags);
-    fFlags[kIsOrtho] = new QCheckBox(tr("Is Orthogonal"), grpFlags);
+    fFlags[kAlphaChannelFlag] = new QBitmaskCheckBox(plBitmap::kAlphaChannelFlag,
+                                                     tr("Alpha Channel"), grpFlags);
+    fFlags[kAlphaBitFlag] = new QBitmaskCheckBox(plBitmap::kAlphaBitFlag,
+                                                 tr("Alpha Bit"), grpFlags);
+    fFlags[kBumpEnvMap] = new QBitmaskCheckBox(plBitmap::kBumpEnvMap,
+                                               tr("Bump Env Map"), grpFlags);
+    fFlags[kForce32Bit] = new QBitmaskCheckBox(plBitmap::kForce32Bit,
+                                               tr("Force 32-bit"), grpFlags);
+    fFlags[kDontThrowAwayImage] = new QBitmaskCheckBox(plBitmap::kDontThrowAwayImage,
+                                                       tr("Don't Throw Away"), grpFlags);
+    fFlags[kForceOneMipLevel] = new QBitmaskCheckBox(plBitmap::kForceOneMipLevel,
+                                                     tr("Force One Level"), grpFlags);
+    fFlags[kNoMaxSize] = new QBitmaskCheckBox(plBitmap::kNoMaxSize,
+                                              tr("No Maximum Size"), grpFlags);
+    fFlags[kIntensityMap] = new QBitmaskCheckBox(plBitmap::kIntensityMap,
+                                                 tr("Intensity Map"), grpFlags);
+    fFlags[kHalfSize] = new QBitmaskCheckBox(plBitmap::kHalfSize,
+                                             tr("Half Size"), grpFlags);
+    fFlags[kUserOwnsBitmap] = new QBitmaskCheckBox(plBitmap::kUserOwnsBitmap,
+                                                   tr("User Owned"), grpFlags);
+    fFlags[kForceRewrite] = new QBitmaskCheckBox(plBitmap::kForceRewrite,
+                                                 tr("Force Rewrite"), grpFlags);
+    fFlags[kForceNonCompressed] = new QBitmaskCheckBox(plBitmap::kForceNonCompressed,
+                                                       tr("Force Non-compressed"), grpFlags);
+    fFlags[kIsTexture] = new QBitmaskCheckBox(plBitmap::kIsTexture,
+                                              tr("Is Texture"), grpFlags);
+    fFlags[kIsOffscreen] = new QBitmaskCheckBox(plBitmap::kIsOffscreen,
+                                                tr("Is Offscreen"), grpFlags);
+    fFlags[kIsProjected] = new QBitmaskCheckBox(plBitmap::kIsProjected,
+                                                tr("Is Projected"), grpFlags);
+    fFlags[kIsOrtho] = new QBitmaskCheckBox(plBitmap::kIsOrtho,
+                                            tr("Is Orthogonal"), grpFlags);
     layFlags->addWidget(fFlags[kAlphaChannelFlag], 0, 0);
     layFlags->addWidget(fFlags[kAlphaBitFlag], 1, 0);
     layFlags->addWidget(fFlags[kBumpEnvMap], 2, 0);
@@ -63,22 +79,18 @@ QCubicEnvironmap::QCubicEnvironmap(plCreatable* pCre, QWidget* parent)
     layFlags->addWidget(fFlags[kIsOffscreen], 1, 3);
     layFlags->addWidget(fFlags[kIsProjected], 2, 3);
     layFlags->addWidget(fFlags[kIsOrtho], 3, 3);
-    fFlags[kAlphaChannelFlag]->setChecked(tex->getFlags() & plBitmap::kAlphaChannelFlag);
-    fFlags[kAlphaBitFlag]->setChecked(tex->getFlags() & plBitmap::kAlphaBitFlag);
-    fFlags[kBumpEnvMap]->setChecked(tex->getFlags() & plBitmap::kBumpEnvMap);
-    fFlags[kForce32Bit]->setChecked(tex->getFlags() & plBitmap::kForce32Bit);
-    fFlags[kDontThrowAwayImage]->setChecked(tex->getFlags() & plBitmap::kDontThrowAwayImage);
-    fFlags[kForceOneMipLevel]->setChecked(tex->getFlags() & plBitmap::kForceOneMipLevel);
-    fFlags[kNoMaxSize]->setChecked(tex->getFlags() & plBitmap::kNoMaxSize);
-    fFlags[kIntensityMap]->setChecked(tex->getFlags() & plBitmap::kIntensityMap);
-    fFlags[kHalfSize]->setChecked(tex->getFlags() & plBitmap::kHalfSize);
-    fFlags[kUserOwnsBitmap]->setChecked(tex->getFlags() & plBitmap::kUserOwnsBitmap);
-    fFlags[kForceRewrite]->setChecked(tex->getFlags() & plBitmap::kForceRewrite);
-    fFlags[kForceNonCompressed]->setChecked(tex->getFlags() & plBitmap::kForceNonCompressed);
-    fFlags[kIsTexture]->setChecked(tex->getFlags() & plBitmap::kIsTexture);
-    fFlags[kIsOffscreen]->setChecked(tex->getFlags() & plBitmap::kIsOffscreen);
-    fFlags[kIsProjected]->setChecked(tex->getFlags() & plBitmap::kIsProjected);
-    fFlags[kIsOrtho]->setChecked(tex->getFlags() & plBitmap::kIsOrtho);
+
+    for (auto cb : fFlags) {
+        cb->setFrom(tex->getFlags());
+        connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            plCubicEnvironmap* tex = plCubicEnvironmap::Convert(fCreatable);
+            tex->setFlags(tex->getFlags() | mask);
+        });
+        connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            plCubicEnvironmap* tex = plCubicEnvironmap::Convert(fCreatable);
+            tex->setFlags(tex->getFlags() & ~mask);
+        });
+    }
 
     QGroupBox* grpFaces = new QGroupBox(tr("Faces"), this);
     fFaces[plCubicEnvironmap::kLeftFace] = new QCreatableLink(grpFaces, false);
@@ -110,26 +122,4 @@ QCubicEnvironmap::QCubicEnvironmap(plCreatable* pCre, QWidget* parent)
     layout->addWidget(grpFlags, 0, 0, 1, 3);
     layout->addWidget(grpFaces, 1, 0, 1, 3);
     layout->addWidget(fPreviewLink, 3, 0, 1, 3);
-}
-
-void QCubicEnvironmap::saveDamage()
-{
-    plCubicEnvironmap* tex = plCubicEnvironmap::Convert(fCreatable);
-
-    tex->setFlags((fFlags[kAlphaChannelFlag]->isChecked() ? plBitmap::kAlphaChannelFlag : 0)
-                | (fFlags[kAlphaBitFlag]->isChecked() ? plBitmap::kAlphaBitFlag : 0)
-                | (fFlags[kBumpEnvMap]->isChecked() ? plBitmap::kBumpEnvMap : 0)
-                | (fFlags[kForce32Bit]->isChecked() ? plBitmap::kForce32Bit : 0)
-                | (fFlags[kDontThrowAwayImage]->isChecked() ? plBitmap::kDontThrowAwayImage : 0)
-                | (fFlags[kForceOneMipLevel]->isChecked() ? plBitmap::kForceOneMipLevel : 0)
-                | (fFlags[kNoMaxSize]->isChecked() ? plBitmap::kNoMaxSize : 0)
-                | (fFlags[kIntensityMap]->isChecked() ? plBitmap::kIntensityMap : 0)
-                | (fFlags[kHalfSize]->isChecked() ? plBitmap::kHalfSize : 0)
-                | (fFlags[kUserOwnsBitmap]->isChecked() ? plBitmap::kUserOwnsBitmap : 0)
-                | (fFlags[kForceRewrite]->isChecked() ? plBitmap::kForceRewrite : 0)
-                | (fFlags[kForceNonCompressed]->isChecked() ? plBitmap::kForceNonCompressed : 0)
-                | (fFlags[kIsTexture]->isChecked() ? plBitmap::kIsTexture : 0)
-                | (fFlags[kIsOffscreen]->isChecked() ? plBitmap::kIsOffscreen : 0)
-                | (fFlags[kIsProjected]->isChecked() ? plBitmap::kIsProjected : 0)
-                | (fFlags[kIsOrtho]->isChecked() ? plBitmap::kIsOrtho : 0));
 }

--- a/src/PrpShop/PRP/Surface/QCubicEnvironmap.h
+++ b/src/PrpShop/PRP/Surface/QCubicEnvironmap.h
@@ -19,6 +19,7 @@
 
 #include "QMipmap.h"
 #include <PRP/Surface/plCubicEnvironmap.h>
+#include "QBitmaskCheckBox.h"
 
 class QCubicEnvironmap : public QCreatable
 {
@@ -32,13 +33,13 @@ protected:
         kHalfSize, kUserOwnsBitmap, kForceRewrite, kForceNonCompressed,
         kIsTexture, kIsOffscreen, kIsProjected, kIsOrtho, kNumBitmapFlags
     };
-    QCheckBox* fFlags[kNumBitmapFlags];
+    QBitmaskCheckBox* fFlags[kNumBitmapFlags];
     QCreatableLink* fFaces[plCubicEnvironmap::kNumFaces];
     QCreatableLink* fPreviewLink;
 
 public:
     QCubicEnvironmap(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
+    void saveDamage() override { }
 };
 
 #endif

--- a/src/PrpShop/PRP/Surface/QCubicEnvironmap.h
+++ b/src/PrpShop/PRP/Surface/QCubicEnvironmap.h
@@ -39,7 +39,6 @@ protected:
 
 public:
     QCubicEnvironmap(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 };
 
 #endif

--- a/src/PrpShop/PRP/Surface/QDynamicTextMap.cpp
+++ b/src/PrpShop/PRP/Surface/QDynamicTextMap.cpp
@@ -31,22 +31,38 @@ QDynamicTextMap::QDynamicTextMap(plCreatable* pCre, QWidget* parent)
     QGridLayout* layFlags = new QGridLayout(grpFlags);
     layFlags->setVerticalSpacing(0);
     layFlags->setHorizontalSpacing(8);
-    fFlags[kAlphaChannelFlag] = new QCheckBox(tr("Alpha Channel"), grpFlags);
-    fFlags[kAlphaBitFlag] = new QCheckBox(tr("Alpha Bit"), grpFlags);
-    fFlags[kBumpEnvMap] = new QCheckBox(tr("Bump Env Map"), grpFlags);
-    fFlags[kForce32Bit] = new QCheckBox(tr("Force 32-bit"), grpFlags);
-    fFlags[kDontThrowAwayImage] = new QCheckBox(tr("Don't Throw Away"), grpFlags);
-    fFlags[kForceOneMipLevel] = new QCheckBox(tr("Force One Level"), grpFlags);
-    fFlags[kNoMaxSize] = new QCheckBox(tr("No Maximum Size"), grpFlags);
-    fFlags[kIntensityMap] = new QCheckBox(tr("Intensity Map"), grpFlags);
-    fFlags[kHalfSize] = new QCheckBox(tr("Half Size"), grpFlags);
-    fFlags[kUserOwnsBitmap] = new QCheckBox(tr("User Owned"), grpFlags);
-    fFlags[kForceRewrite] = new QCheckBox(tr("Force Rewrite"), grpFlags);
-    fFlags[kForceNonCompressed] = new QCheckBox(tr("Force Non-compressed"), grpFlags);
-    fFlags[kIsTexture] = new QCheckBox(tr("Is Texture"), grpFlags);
-    fFlags[kIsOffscreen] = new QCheckBox(tr("Is Offscreen"), grpFlags);
-    fFlags[kIsProjected] = new QCheckBox(tr("Is Projected"), grpFlags);
-    fFlags[kIsOrtho] = new QCheckBox(tr("Is Orthogonal"), grpFlags);
+    fFlags[kAlphaChannelFlag] = new QBitmaskCheckBox(plBitmap::kAlphaChannelFlag,
+                                                     tr("Alpha Channel"), grpFlags);
+    fFlags[kAlphaBitFlag] = new QBitmaskCheckBox(plBitmap::kAlphaBitFlag,
+                                                 tr("Alpha Bit"), grpFlags);
+    fFlags[kBumpEnvMap] = new QBitmaskCheckBox(plBitmap::kBumpEnvMap,
+                                               tr("Bump Env Map"), grpFlags);
+    fFlags[kForce32Bit] = new QBitmaskCheckBox(plBitmap::kForce32Bit,
+                                               tr("Force 32-bit"), grpFlags);
+    fFlags[kDontThrowAwayImage] = new QBitmaskCheckBox(plBitmap::kDontThrowAwayImage,
+                                                       tr("Don't Throw Away"), grpFlags);
+    fFlags[kForceOneMipLevel] = new QBitmaskCheckBox(plBitmap::kForceOneMipLevel,
+                                                     tr("Force One Level"), grpFlags);
+    fFlags[kNoMaxSize] = new QBitmaskCheckBox(plBitmap::kNoMaxSize,
+                                              tr("No Maximum Size"), grpFlags);
+    fFlags[kIntensityMap] = new QBitmaskCheckBox(plBitmap::kIntensityMap,
+                                                 tr("Intensity Map"), grpFlags);
+    fFlags[kHalfSize] = new QBitmaskCheckBox(plBitmap::kHalfSize,
+                                             tr("Half Size"), grpFlags);
+    fFlags[kUserOwnsBitmap] = new QBitmaskCheckBox(plBitmap::kUserOwnsBitmap,
+                                                   tr("User Owned"), grpFlags);
+    fFlags[kForceRewrite] = new QBitmaskCheckBox(plBitmap::kForceRewrite,
+                                                 tr("Force Rewrite"), grpFlags);
+    fFlags[kForceNonCompressed] = new QBitmaskCheckBox(plBitmap::kForceNonCompressed,
+                                                       tr("Force Non-compressed"), grpFlags);
+    fFlags[kIsTexture] = new QBitmaskCheckBox(plBitmap::kIsTexture,
+                                              tr("Is Texture"), grpFlags);
+    fFlags[kIsOffscreen] = new QBitmaskCheckBox(plBitmap::kIsOffscreen,
+                                                tr("Is Offscreen"), grpFlags);
+    fFlags[kIsProjected] = new QBitmaskCheckBox(plBitmap::kIsProjected,
+                                                tr("Is Projected"), grpFlags);
+    fFlags[kIsOrtho] = new QBitmaskCheckBox(plBitmap::kIsOrtho,
+                                            tr("Is Orthogonal"), grpFlags);
     layFlags->addWidget(fFlags[kAlphaChannelFlag], 0, 0);
     layFlags->addWidget(fFlags[kAlphaBitFlag], 1, 0);
     layFlags->addWidget(fFlags[kBumpEnvMap], 2, 0);
@@ -63,22 +79,18 @@ QDynamicTextMap::QDynamicTextMap(plCreatable* pCre, QWidget* parent)
     layFlags->addWidget(fFlags[kIsOffscreen], 1, 3);
     layFlags->addWidget(fFlags[kIsProjected], 2, 3);
     layFlags->addWidget(fFlags[kIsOrtho], 3, 3);
-    fFlags[kAlphaChannelFlag]->setChecked(tex->getFlags() & plBitmap::kAlphaChannelFlag);
-    fFlags[kAlphaBitFlag]->setChecked(tex->getFlags() & plBitmap::kAlphaBitFlag);
-    fFlags[kBumpEnvMap]->setChecked(tex->getFlags() & plBitmap::kBumpEnvMap);
-    fFlags[kForce32Bit]->setChecked(tex->getFlags() & plBitmap::kForce32Bit);
-    fFlags[kDontThrowAwayImage]->setChecked(tex->getFlags() & plBitmap::kDontThrowAwayImage);
-    fFlags[kForceOneMipLevel]->setChecked(tex->getFlags() & plBitmap::kForceOneMipLevel);
-    fFlags[kNoMaxSize]->setChecked(tex->getFlags() & plBitmap::kNoMaxSize);
-    fFlags[kIntensityMap]->setChecked(tex->getFlags() & plBitmap::kIntensityMap);
-    fFlags[kHalfSize]->setChecked(tex->getFlags() & plBitmap::kHalfSize);
-    fFlags[kUserOwnsBitmap]->setChecked(tex->getFlags() & plBitmap::kUserOwnsBitmap);
-    fFlags[kForceRewrite]->setChecked(tex->getFlags() & plBitmap::kForceRewrite);
-    fFlags[kForceNonCompressed]->setChecked(tex->getFlags() & plBitmap::kForceNonCompressed);
-    fFlags[kIsTexture]->setChecked(tex->getFlags() & plBitmap::kIsTexture);
-    fFlags[kIsOffscreen]->setChecked(tex->getFlags() & plBitmap::kIsOffscreen);
-    fFlags[kIsProjected]->setChecked(tex->getFlags() & plBitmap::kIsProjected);
-    fFlags[kIsOrtho]->setChecked(tex->getFlags() & plBitmap::kIsOrtho);
+
+    for (auto cb : fFlags) {
+        cb->setFrom(tex->getFlags());
+        connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            plDynamicTextMap* tex = plDynamicTextMap::Convert(fCreatable);
+            tex->setFlags(tex->getFlags() | mask);
+        });
+        connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            plDynamicTextMap* tex = plDynamicTextMap::Convert(fCreatable);
+            tex->setFlags(tex->getFlags() & ~mask);
+        });
+    }
 
     fWidth = new QIntEdit(this);
     fWidth->setRange(0, 0x7FFFFFFF);
@@ -105,22 +117,6 @@ void QDynamicTextMap::saveDamage()
 {
     plDynamicTextMap* tex = plDynamicTextMap::Convert(fCreatable);
 
-    tex->setFlags((fFlags[kAlphaChannelFlag]->isChecked() ? plBitmap::kAlphaChannelFlag : 0)
-                | (fFlags[kAlphaBitFlag]->isChecked() ? plBitmap::kAlphaBitFlag : 0)
-                | (fFlags[kBumpEnvMap]->isChecked() ? plBitmap::kBumpEnvMap : 0)
-                | (fFlags[kForce32Bit]->isChecked() ? plBitmap::kForce32Bit : 0)
-                | (fFlags[kDontThrowAwayImage]->isChecked() ? plBitmap::kDontThrowAwayImage : 0)
-                | (fFlags[kForceOneMipLevel]->isChecked() ? plBitmap::kForceOneMipLevel : 0)
-                | (fFlags[kNoMaxSize]->isChecked() ? plBitmap::kNoMaxSize : 0)
-                | (fFlags[kIntensityMap]->isChecked() ? plBitmap::kIntensityMap : 0)
-                | (fFlags[kHalfSize]->isChecked() ? plBitmap::kHalfSize : 0)
-                | (fFlags[kUserOwnsBitmap]->isChecked() ? plBitmap::kUserOwnsBitmap : 0)
-                | (fFlags[kForceRewrite]->isChecked() ? plBitmap::kForceRewrite : 0)
-                | (fFlags[kForceNonCompressed]->isChecked() ? plBitmap::kForceNonCompressed : 0)
-                | (fFlags[kIsTexture]->isChecked() ? plBitmap::kIsTexture : 0)
-                | (fFlags[kIsOffscreen]->isChecked() ? plBitmap::kIsOffscreen : 0)
-                | (fFlags[kIsProjected]->isChecked() ? plBitmap::kIsProjected : 0)
-                | (fFlags[kIsOrtho]->isChecked() ? plBitmap::kIsOrtho : 0));
     tex->setVisWidth(fWidth->value());
     tex->setVisHeight(fHeight->value());
     tex->setHasAlpha(fHasAlpha->isChecked());

--- a/src/PrpShop/PRP/Surface/QDynamicTextMap.cpp
+++ b/src/PrpShop/PRP/Surface/QDynamicTextMap.cpp
@@ -102,6 +102,11 @@ QDynamicTextMap::QDynamicTextMap(plCreatable* pCre, QWidget* parent)
     fHasAlpha = new QCheckBox(tr("Has Alpha"), this);
     fHasAlpha->setChecked(tex->hasAlpha());
 
+    connect(fHasAlpha, &QCheckBox::clicked, this, [this](bool checked) {
+        plDynamicTextMap* tex = plDynamicTextMap::Convert(fCreatable);
+        tex->setHasAlpha(checked);
+    });
+
     QGridLayout* layout = new QGridLayout(this);
     layout->setContentsMargins(8, 8, 8, 8);
     layout->addWidget(grpFlags, 0, 0, 1, 4);
@@ -119,5 +124,4 @@ void QDynamicTextMap::saveDamage()
 
     tex->setVisWidth(fWidth->value());
     tex->setVisHeight(fHeight->value());
-    tex->setHasAlpha(fHasAlpha->isChecked());
 }

--- a/src/PrpShop/PRP/Surface/QDynamicTextMap.h
+++ b/src/PrpShop/PRP/Surface/QDynamicTextMap.h
@@ -19,6 +19,7 @@
 
 #include "QMipmap.h"
 #include <PRP/Surface/plDynamicTextMap.h>
+#include "QBitmaskCheckBox.h"
 
 class QDynamicTextMap : public QCreatable
 {
@@ -32,7 +33,7 @@ protected:
         kHalfSize, kUserOwnsBitmap, kForceRewrite, kForceNonCompressed,
         kIsTexture, kIsOffscreen, kIsProjected, kIsOrtho, kNumBitmapFlags
     };
-    QCheckBox* fFlags[kNumBitmapFlags];
+    QBitmaskCheckBox* fFlags[kNumBitmapFlags];
     QIntEdit* fWidth;
     QIntEdit* fHeight;
     QCheckBox* fHasAlpha;

--- a/src/PrpShop/PRP/Surface/QFadeOpacityMod.cpp
+++ b/src/PrpShop/PRP/Surface/QFadeOpacityMod.cpp
@@ -39,6 +39,11 @@ QFadeOpacityMod::QFadeOpacityMod(plCreatable* pCre, QWidget* parent)
     layFlags->addWidget(fFlags[kBoundsCenter], 0, 0);
     fFlags[kBoundsCenter]->setChecked(mod->getFlag(plFadeOpacityMod::kBoundsCenter));
 
+    connect(fFlags[kBoundsCenter], &QCheckBox::clicked, this, [this](bool checked) {
+        plFadeOpacityMod* mod = plFadeOpacityMod::Convert(fCreatable);
+        mod->setFlag(plFadeOpacityMod::kBoundsCenter, checked);
+    });
+
     fUp = new QFloatEdit(this);
     fUp->setValue(mod->getFadeUp());
 
@@ -59,7 +64,6 @@ void QFadeOpacityMod::saveDamage()
 {
     plFadeOpacityMod* mod = plFadeOpacityMod::Convert(fCreatable);
 
-    mod->setFlag(plFadeOpacityMod::kBoundsCenter, fFlags[kBoundsCenter]->isChecked());
     mod->setFadeUp(fUp->value());
     mod->setFadeDown(fDown->value());
 }

--- a/src/PrpShop/PRP/Surface/QLayer.cpp
+++ b/src/PrpShop/PRP/Surface/QLayer.cpp
@@ -50,33 +50,60 @@ QLayer::QLayer(plCreatable* pCre, QWidget* parent)
     QGridLayout* blendLayout = new QGridLayout(blendWidget);
     blendLayout->setVerticalSpacing(0);
     blendLayout->setHorizontalSpacing(8);
-    fBlendFlags[kBlendTest] = new QCheckBox(tr("Test"), blendWidget);
-    fBlendFlags[kBlendAlpha] = new QCheckBox(tr("Alpha"), blendWidget);
-    fBlendFlags[kBlendMult] = new QCheckBox(tr("Mult"), blendWidget);
-    fBlendFlags[kBlendAdd] = new QCheckBox(tr("Add"), blendWidget);
-    fBlendFlags[kBlendAddColorTimesAlpha] = new QCheckBox(tr("Add Color × Alpha"), blendWidget);
-    fBlendFlags[kBlendAntiAlias] = new QCheckBox(tr("Anti-Alias"), blendWidget);
-    fBlendFlags[kBlendDetail] = new QCheckBox(tr("Detail"), blendWidget);
-    fBlendFlags[kBlendNoColor] = new QCheckBox(tr("No Color"), blendWidget);
-    fBlendFlags[kBlendMADD] = new QCheckBox(tr("MADD"), blendWidget);
-    fBlendFlags[kBlendDot3] = new QCheckBox(tr("Dot3"), blendWidget);
-    fBlendFlags[kBlendAddSigned] = new QCheckBox(tr("Add Signed"), blendWidget);
-    fBlendFlags[kBlendAddSigned2X] = new QCheckBox(tr("Add Signed 2X"), blendWidget);
-    fBlendFlags[kBlendInvertAlpha] = new QCheckBox(tr("Invert Alpha"), blendWidget);
-    fBlendFlags[kBlendInvertColor] = new QCheckBox(tr("Invert Color"), blendWidget);
-    fBlendFlags[kBlendAlphaMult] = new QCheckBox(tr("Alpha Mult"), blendWidget);
-    fBlendFlags[kBlendAlphaAdd] = new QCheckBox(tr("Alpha Add"), blendWidget);
-    fBlendFlags[kBlendNoVtxAlpha] = new QCheckBox(tr("No Vertex Alpha"), blendWidget);
-    fBlendFlags[kBlendNoTexColor] = new QCheckBox(tr("No Texture Color"), blendWidget);
-    fBlendFlags[kBlendNoTexAlpha] = new QCheckBox(tr("No Texture Alpha"), blendWidget);
-    fBlendFlags[kBlendInvertVtxAlpha] = new QCheckBox(tr("Invert Vertex Alpha"), blendWidget);
-    fBlendFlags[kBlendAlphaAlways] = new QCheckBox(tr("Alpha Always"), blendWidget);
-    fBlendFlags[kBlendInvertFinalColor] = new QCheckBox(tr("Invert Final Color"), blendWidget);
-    fBlendFlags[kBlendInvertFinalAlpha] = new QCheckBox(tr("Invert Final Alpha"), blendWidget);
-    fBlendFlags[kBlendEnvBumpNext] = new QCheckBox(tr("Env Bump Next"), blendWidget);
-    fBlendFlags[kBlendSubtract] = new QCheckBox(tr("Subtract"), blendWidget);
-    fBlendFlags[kBlendRevSubtract] = new QCheckBox(tr("Rev Subtract"), blendWidget);
-    fBlendFlags[kBlendAlphaTestHigh] = new QCheckBox(tr("Alpha Test High"), blendWidget);
+    fBlendFlags[kBlendTest] = new QBitmaskCheckBox(hsGMatState::kBlendTest,
+            tr("Test"), blendWidget);
+    fBlendFlags[kBlendAlpha] = new QBitmaskCheckBox(hsGMatState::kBlendAlpha,
+            tr("Alpha"), blendWidget);
+    fBlendFlags[kBlendMult] = new QBitmaskCheckBox(hsGMatState::kBlendMult,
+            tr("Mult"), blendWidget);
+    fBlendFlags[kBlendAdd] = new QBitmaskCheckBox(hsGMatState::kBlendAdd,
+            tr("Add"), blendWidget);
+    fBlendFlags[kBlendAddColorTimesAlpha] = new QBitmaskCheckBox(hsGMatState::kBlendAddColorTimesAlpha,
+            tr("Add Color × Alpha"), blendWidget);
+    fBlendFlags[kBlendAntiAlias] = new QBitmaskCheckBox(hsGMatState::kBlendAntiAlias,
+            tr("Anti-Alias"), blendWidget);
+    fBlendFlags[kBlendDetail] = new QBitmaskCheckBox(hsGMatState::kBlendDetail,
+            tr("Detail"), blendWidget);
+    fBlendFlags[kBlendNoColor] = new QBitmaskCheckBox(hsGMatState::kBlendNoColor,
+            tr("No Color"), blendWidget);
+    fBlendFlags[kBlendMADD] = new QBitmaskCheckBox(hsGMatState::kBlendMADD,
+            tr("MADD"), blendWidget);
+    fBlendFlags[kBlendDot3] = new QBitmaskCheckBox(hsGMatState::kBlendDot3,
+            tr("Dot3"), blendWidget);
+    fBlendFlags[kBlendAddSigned] = new QBitmaskCheckBox(hsGMatState::kBlendAddSigned,
+            tr("Add Signed"), blendWidget);
+    fBlendFlags[kBlendAddSigned2X] = new QBitmaskCheckBox(hsGMatState::kBlendAddSigned2X,
+            tr("Add Signed 2X"), blendWidget);
+    fBlendFlags[kBlendInvertAlpha] = new QBitmaskCheckBox(hsGMatState::kBlendInvertAlpha,
+            tr("Invert Alpha"), blendWidget);
+    fBlendFlags[kBlendInvertColor] = new QBitmaskCheckBox(hsGMatState::kBlendInvertColor,
+            tr("Invert Color"), blendWidget);
+    fBlendFlags[kBlendAlphaMult] = new QBitmaskCheckBox(hsGMatState::kBlendAlphaMult,
+            tr("Alpha Mult"), blendWidget);
+    fBlendFlags[kBlendAlphaAdd] = new QBitmaskCheckBox(hsGMatState::kBlendAlphaAdd,
+            tr("Alpha Add"), blendWidget);
+    fBlendFlags[kBlendNoVtxAlpha] = new QBitmaskCheckBox(hsGMatState::kBlendNoVtxAlpha,
+            tr("No Vertex Alpha"), blendWidget);
+    fBlendFlags[kBlendNoTexColor] = new QBitmaskCheckBox(hsGMatState::kBlendNoTexColor,
+            tr("No Texture Color"), blendWidget);
+    fBlendFlags[kBlendNoTexAlpha] = new QBitmaskCheckBox(hsGMatState::kBlendNoTexAlpha,
+            tr("No Texture Alpha"), blendWidget);
+    fBlendFlags[kBlendInvertVtxAlpha] = new QBitmaskCheckBox(hsGMatState::kBlendInvertVtxAlpha,
+            tr("Invert Vertex Alpha"), blendWidget);
+    fBlendFlags[kBlendAlphaAlways] = new QBitmaskCheckBox(hsGMatState::kBlendAlphaAlways,
+            tr("Alpha Always"), blendWidget);
+    fBlendFlags[kBlendInvertFinalColor] = new QBitmaskCheckBox(hsGMatState::kBlendInvertFinalColor,
+            tr("Invert Final Color"), blendWidget);
+    fBlendFlags[kBlendInvertFinalAlpha] = new QBitmaskCheckBox(hsGMatState::kBlendInvertFinalAlpha,
+            tr("Invert Final Alpha"), blendWidget);
+    fBlendFlags[kBlendEnvBumpNext] = new QBitmaskCheckBox(hsGMatState::kBlendEnvBumpNext,
+            tr("Env Bump Next"), blendWidget);
+    fBlendFlags[kBlendSubtract] = new QBitmaskCheckBox(hsGMatState::kBlendSubtract,
+            tr("Subtract"), blendWidget);
+    fBlendFlags[kBlendRevSubtract] = new QBitmaskCheckBox(hsGMatState::kBlendRevSubtract,
+            tr("Rev Subtract"), blendWidget);
+    fBlendFlags[kBlendAlphaTestHigh] = new QBitmaskCheckBox(hsGMatState::kBlendAlphaTestHigh,
+            tr("Alpha Test High"), blendWidget);
     blendLayout->addWidget(fBlendFlags[kBlendTest], 0, 0);
     blendLayout->addWidget(fBlendFlags[kBlendAddColorTimesAlpha], 0, 1);
     blendLayout->addWidget(fBlendFlags[kBlendInvertAlpha], 0, 2);
@@ -106,17 +133,37 @@ QLayer::QLayer(plCreatable* pCre, QWidget* parent)
     blendLayout->addWidget(fBlendFlags[kBlendEnvBumpNext], 6, 3);
     blendLayout->addItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::MinimumExpanding), 7, 0, 1, 4);
 
+    const hsGMatState &state = lay->getState();
+    for (auto cb : fBlendFlags) {
+        cb->setFrom(state.fBlendFlags);
+        connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            plLayer* lay = plLayer::Convert(fCreatable);
+            lay->getState().fBlendFlags |= mask;
+        });
+        connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            plLayer* lay = plLayer::Convert(fCreatable);
+            lay->getState().fBlendFlags &= ~mask;
+        });
+    }
+
     QWidget* clampZWidget = new QWidget(flagTab);
     QGridLayout* clampZLayout = new QGridLayout(clampZWidget);
     clampZLayout->setVerticalSpacing(0);
     clampZLayout->setHorizontalSpacing(8);
-    fClampFlags[kClampTextureU] = new QCheckBox(tr("Clamp Texture U"), clampZWidget);
-    fClampFlags[kClampTextureV] = new QCheckBox(tr("Clamp Texture V"), clampZWidget);
-    fZFlags[kZIncLayer] = new QCheckBox(tr("Increment Z Layer"), clampZWidget);
-    fZFlags[kZClearZ] = new QCheckBox(tr("Clear Z"), clampZWidget);
-    fZFlags[kZNoZRead] = new QCheckBox(tr("No Z Read"), clampZWidget);
-    fZFlags[kZNoZWrite] = new QCheckBox(tr("No Z Write"), clampZWidget);
-    fZFlags[kZLODBias] = new QCheckBox(tr("LOD Bias"), clampZWidget);
+    fClampFlags[kClampTextureU] = new QBitmaskCheckBox(hsGMatState::kClampTextureU,
+            tr("Clamp Texture U"), clampZWidget);
+    fClampFlags[kClampTextureV] = new QBitmaskCheckBox(hsGMatState::kClampTextureV,
+            tr("Clamp Texture V"), clampZWidget);
+    fZFlags[kZIncLayer] = new QBitmaskCheckBox(hsGMatState::kZIncLayer,
+            tr("Increment Z Layer"), clampZWidget);
+    fZFlags[kZClearZ] = new QBitmaskCheckBox(hsGMatState::kZClearZ,
+            tr("Clear Z"), clampZWidget);
+    fZFlags[kZNoZRead] = new QBitmaskCheckBox(hsGMatState::kZNoZRead,
+            tr("No Z Read"), clampZWidget);
+    fZFlags[kZNoZWrite] = new QBitmaskCheckBox(hsGMatState::kZNoZWrite,
+            tr("No Z Write"), clampZWidget);
+    fZFlags[kZLODBias] = new QBitmaskCheckBox(hsGMatState::kZLODBias,
+            tr("LOD Bias"), clampZWidget);
     clampZLayout->addWidget(fClampFlags[kClampTextureU], 0, 0);
     clampZLayout->addWidget(fClampFlags[kClampTextureV], 0, 1);
     clampZLayout->addItem(new QSpacerItem(0, 16), 1, 0, 1, 2);
@@ -127,26 +174,66 @@ QLayer::QLayer(plCreatable* pCre, QWidget* parent)
     clampZLayout->addWidget(fZFlags[kZLODBias], 4, 0);
     clampZLayout->addItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::MinimumExpanding), 5, 0, 1, 2);
 
+    for (auto cb : fClampFlags) {
+        cb->setFrom(state.fClampFlags);
+        connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            plLayer* lay = plLayer::Convert(fCreatable);
+            lay->getState().fClampFlags |= mask;
+        });
+        connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            plLayer* lay = plLayer::Convert(fCreatable);
+            lay->getState().fClampFlags &= ~mask;
+        });
+    }
+
+    for (auto cb : fZFlags) {
+        cb->setFrom(state.fZFlags);
+        connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            plLayer* lay = plLayer::Convert(fCreatable);
+            lay->getState().fZFlags |= mask;
+        });
+        connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            plLayer* lay = plLayer::Convert(fCreatable);
+            lay->getState().fZFlags &= ~mask;
+        });
+    }
+
     QWidget* shadeWidget = new QWidget(flagTab);
     QGridLayout* shadeLayout = new QGridLayout(shadeWidget);
     shadeLayout->setVerticalSpacing(0);
     shadeLayout->setHorizontalSpacing(8);
-    fShadeFlags[kShadeSoftShadow] = new QCheckBox(tr("Soft Shadow"), shadeWidget);
-    fShadeFlags[kShadeNoProjectors] = new QCheckBox(tr("No Projectors"), shadeWidget);
-    fShadeFlags[kShadeEnvironMap] = new QCheckBox(tr("EnvironMap"), shadeWidget);
-    fShadeFlags[kShadeVertexShade] = new QCheckBox(tr("Vertex Shade"), shadeWidget);
-    fShadeFlags[kShadeBlack] = new QCheckBox(tr("Black"), shadeWidget);
-    fShadeFlags[kShadeSpecular] = new QCheckBox(tr("Specular"), shadeWidget);
-    fShadeFlags[kShadeNoFog] = new QCheckBox(tr("No Fog"), shadeWidget);
-    fShadeFlags[kShadeWhite] = new QCheckBox(tr("White"), shadeWidget);
-    fShadeFlags[kShadeSpecularAlpha] = new QCheckBox(tr("Specular Alpha"), shadeWidget);
-    fShadeFlags[kShadeSpecularColor] = new QCheckBox(tr("Specular Color"), shadeWidget);
-    fShadeFlags[kShadeSpecularHighlight] = new QCheckBox(tr("Specular Highlight"), shadeWidget);
-    fShadeFlags[kShadeVertColShade] = new QCheckBox(tr("Vtx Color Shade"), shadeWidget);
-    fShadeFlags[kShadeInherit] = new QCheckBox(tr("Inherit"), shadeWidget);
-    fShadeFlags[kShadeIgnoreVtxIllum] = new QCheckBox(tr("Ignore Vtx Illum"), shadeWidget);
-    fShadeFlags[kShadeEmissive] = new QCheckBox(tr("Emissive"), shadeWidget);
-    fShadeFlags[kShadeReallyNoFog] = new QCheckBox(tr("Really No Fog"), shadeWidget);
+    fShadeFlags[kShadeSoftShadow] = new QBitmaskCheckBox(hsGMatState::kShadeSoftShadow,
+            tr("Soft Shadow"), shadeWidget);
+    fShadeFlags[kShadeNoProjectors] = new QBitmaskCheckBox(hsGMatState::kShadeNoProjectors,
+            tr("No Projectors"), shadeWidget);
+    fShadeFlags[kShadeEnvironMap] = new QBitmaskCheckBox(hsGMatState::kShadeEnvironMap,
+            tr("EnvironMap"), shadeWidget);
+    fShadeFlags[kShadeVertexShade] = new QBitmaskCheckBox(hsGMatState::kShadeVertexShade,
+            tr("Vertex Shade"), shadeWidget);
+    fShadeFlags[kShadeBlack] = new QBitmaskCheckBox(hsGMatState::kShadeBlack,
+            tr("Black"), shadeWidget);
+    fShadeFlags[kShadeSpecular] = new QBitmaskCheckBox(hsGMatState::kShadeSpecular,
+            tr("Specular"), shadeWidget);
+    fShadeFlags[kShadeNoFog] = new QBitmaskCheckBox(hsGMatState::kShadeNoFog,
+            tr("No Fog"), shadeWidget);
+    fShadeFlags[kShadeWhite] = new QBitmaskCheckBox(hsGMatState::kShadeWhite,
+            tr("White"), shadeWidget);
+    fShadeFlags[kShadeSpecularAlpha] = new QBitmaskCheckBox(hsGMatState::kShadeSpecularAlpha,
+            tr("Specular Alpha"), shadeWidget);
+    fShadeFlags[kShadeSpecularColor] = new QBitmaskCheckBox(hsGMatState::kShadeSpecularColor,
+            tr("Specular Color"), shadeWidget);
+    fShadeFlags[kShadeSpecularHighlight] = new QBitmaskCheckBox(hsGMatState::kShadeSpecularHighlight,
+            tr("Specular Highlight"), shadeWidget);
+    fShadeFlags[kShadeVertColShade] = new QBitmaskCheckBox(hsGMatState::kShadeVertColShade,
+            tr("Vtx Color Shade"), shadeWidget);
+    fShadeFlags[kShadeInherit] = new QBitmaskCheckBox(hsGMatState::kShadeInherit,
+            tr("Inherit"), shadeWidget);
+    fShadeFlags[kShadeIgnoreVtxIllum] = new QBitmaskCheckBox(hsGMatState::kShadeIgnoreVtxIllum,
+            tr("Ignore Vtx Illum"), shadeWidget);
+    fShadeFlags[kShadeEmissive] = new QBitmaskCheckBox(hsGMatState::kShadeEmissive,
+            tr("Emissive"), shadeWidget);
+    fShadeFlags[kShadeReallyNoFog] = new QBitmaskCheckBox(hsGMatState::kShadeReallyNoFog,
+            tr("Really No Fog"), shadeWidget);
     shadeLayout->addWidget(fShadeFlags[kShadeSoftShadow], 0, 0);
     shadeLayout->addWidget(fShadeFlags[kShadeBlack], 0, 1);
     shadeLayout->addWidget(fShadeFlags[kShadeSpecularAlpha], 0, 2);
@@ -165,33 +252,68 @@ QLayer::QLayer(plCreatable* pCre, QWidget* parent)
     shadeLayout->addWidget(fShadeFlags[kShadeReallyNoFog], 3, 3);
     shadeLayout->addItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::MinimumExpanding), 4, 0, 1, 4);
 
+    for (auto cb : fShadeFlags) {
+        cb->setFrom(state.fShadeFlags);
+        connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            plLayer* lay = plLayer::Convert(fCreatable);
+            lay->getState().fShadeFlags |= mask;
+        });
+        connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            plLayer* lay = plLayer::Convert(fCreatable);
+            lay->getState().fShadeFlags &= ~mask;
+        });
+    }
+
     QWidget* miscWidget = new QWidget(flagTab);
     QGridLayout* miscLayout = new QGridLayout(miscWidget);
     miscLayout->setVerticalSpacing(0);
     miscLayout->setHorizontalSpacing(8);
-    fMiscFlags[kMiscWireFrame] = new QCheckBox(tr("Wire Frame"), miscWidget);
-    fMiscFlags[kMiscDrawMeshOutlines] = new QCheckBox(tr("Mesh Outlines"), miscWidget);
-    fMiscFlags[kMiscTwoSided] = new QCheckBox(tr("Two-Sided"), miscWidget);
-    fMiscFlags[kMiscDrawAsSplats] = new QCheckBox(tr("Draw as Splats"), miscWidget);
-    fMiscFlags[kMiscAdjustPlane] = new QCheckBox(tr("Adjust Plane"), miscWidget);
-    fMiscFlags[kMiscAdjustCylinder] = new QCheckBox(tr("Adjust Cylinder"), miscWidget);
-    fMiscFlags[kMiscAdjustSphere] = new QCheckBox(tr("Adjust Sphere"), miscWidget);
-    fMiscFlags[kMiscTroubledLoner] = new QCheckBox(tr("Troubled Loner"), miscWidget);
-    fMiscFlags[kMiscBindSkip] = new QCheckBox(tr("Bind Skip"), miscWidget);
-    fMiscFlags[kMiscBindMask] = new QCheckBox(tr("Bind Mask"), miscWidget);
-    fMiscFlags[kMiscBindNext] = new QCheckBox(tr("Bind Next"), miscWidget);
-    fMiscFlags[kMiscLightMap] = new QCheckBox(tr("Light Map"), miscWidget);
-    fMiscFlags[kMiscUseReflectionXform] = new QCheckBox(tr("Use Reflec Xform"), miscWidget);
-    fMiscFlags[kMiscPerspProjection] = new QCheckBox(tr("Persp Projection"), miscWidget);
-    fMiscFlags[kMiscOrthoProjection] = new QCheckBox(tr("Ortho Projection"), miscWidget);
-    fMiscFlags[kMiscRestartPassHere] = new QCheckBox(tr("Restart Pass Here"), miscWidget);
-    fMiscFlags[kMiscBumpLayer] = new QCheckBox(tr("Bump Layer"), miscWidget);
-    fMiscFlags[kMiscBumpDu] = new QCheckBox(tr("Bump DU"), miscWidget);
-    fMiscFlags[kMiscBumpDv] = new QCheckBox(tr("Bump DV"), miscWidget);
-    fMiscFlags[kMiscBumpDw] = new QCheckBox(tr("Bump DW"), miscWidget);
-    fMiscFlags[kMiscNoShadowAlpha] = new QCheckBox(tr("No Shadow Alpha"), miscWidget);
-    fMiscFlags[kMiscUseRefractionXform] = new QCheckBox(tr("Use Refrac Xform"), miscWidget);
-    fMiscFlags[kMiscCam2Screen] = new QCheckBox(tr("Cam 2 Screen"), miscWidget);
+    fMiscFlags[kMiscWireFrame] = new QBitmaskCheckBox(hsGMatState::kMiscWireFrame,
+            tr("Wire Frame"), miscWidget);
+    fMiscFlags[kMiscDrawMeshOutlines] = new QBitmaskCheckBox(hsGMatState::kMiscDrawMeshOutlines,
+            tr("Mesh Outlines"), miscWidget);
+    fMiscFlags[kMiscTwoSided] = new QBitmaskCheckBox(hsGMatState::kMiscTwoSided,
+            tr("Two-Sided"), miscWidget);
+    fMiscFlags[kMiscDrawAsSplats] = new QBitmaskCheckBox(hsGMatState::kMiscDrawAsSplats,
+            tr("Draw as Splats"), miscWidget);
+    fMiscFlags[kMiscAdjustPlane] = new QBitmaskCheckBox(hsGMatState::kMiscAdjustPlane,
+            tr("Adjust Plane"), miscWidget);
+    fMiscFlags[kMiscAdjustCylinder] = new QBitmaskCheckBox(hsGMatState::kMiscAdjustCylinder,
+            tr("Adjust Cylinder"), miscWidget);
+    fMiscFlags[kMiscAdjustSphere] = new QBitmaskCheckBox(hsGMatState::kMiscAdjustSphere,
+            tr("Adjust Sphere"), miscWidget);
+    fMiscFlags[kMiscTroubledLoner] = new QBitmaskCheckBox(hsGMatState::kMiscTroubledLoner,
+            tr("Troubled Loner"), miscWidget);
+    fMiscFlags[kMiscBindSkip] = new QBitmaskCheckBox(hsGMatState::kMiscBindSkip,
+            tr("Bind Skip"), miscWidget);
+    fMiscFlags[kMiscBindMask] = new QBitmaskCheckBox(hsGMatState::kMiscBindMask,
+            tr("Bind Mask"), miscWidget);
+    fMiscFlags[kMiscBindNext] = new QBitmaskCheckBox(hsGMatState::kMiscBindNext,
+            tr("Bind Next"), miscWidget);
+    fMiscFlags[kMiscLightMap] = new QBitmaskCheckBox(hsGMatState::kMiscLightMap,
+            tr("Light Map"), miscWidget);
+    fMiscFlags[kMiscUseReflectionXform] = new QBitmaskCheckBox(hsGMatState::kMiscUseReflectionXform,
+            tr("Use Reflec Xform"), miscWidget);
+    fMiscFlags[kMiscPerspProjection] = new QBitmaskCheckBox(hsGMatState::kMiscPerspProjection,
+            tr("Persp Projection"), miscWidget);
+    fMiscFlags[kMiscOrthoProjection] = new QBitmaskCheckBox(hsGMatState::kMiscOrthoProjection,
+            tr("Ortho Projection"), miscWidget);
+    fMiscFlags[kMiscRestartPassHere] = new QBitmaskCheckBox(hsGMatState::kMiscRestartPassHere,
+            tr("Restart Pass Here"), miscWidget);
+    fMiscFlags[kMiscBumpLayer] = new QBitmaskCheckBox(hsGMatState::kMiscBumpLayer,
+            tr("Bump Layer"), miscWidget);
+    fMiscFlags[kMiscBumpDu] = new QBitmaskCheckBox(hsGMatState::kMiscBumpDu,
+            tr("Bump DU"), miscWidget);
+    fMiscFlags[kMiscBumpDv] = new QBitmaskCheckBox(hsGMatState::kMiscBumpDv,
+            tr("Bump DV"), miscWidget);
+    fMiscFlags[kMiscBumpDw] = new QBitmaskCheckBox(hsGMatState::kMiscBumpDw,
+            tr("Bump DW"), miscWidget);
+    fMiscFlags[kMiscNoShadowAlpha] = new QBitmaskCheckBox(hsGMatState::kMiscNoShadowAlpha,
+            tr("No Shadow Alpha"), miscWidget);
+    fMiscFlags[kMiscUseRefractionXform] = new QBitmaskCheckBox(hsGMatState::kMiscUseRefractionXform,
+            tr("Use Refrac Xform"), miscWidget);
+    fMiscFlags[kMiscCam2Screen] = new QBitmaskCheckBox(hsGMatState::kMiscCam2Screen,
+            tr("Cam 2 Screen"), miscWidget);
     miscLayout->addWidget(fMiscFlags[kMiscWireFrame], 0, 0);
     miscLayout->addWidget(fMiscFlags[kMiscDrawAsSplats], 0, 1);
     miscLayout->addWidget(fMiscFlags[kMiscBumpLayer], 0, 2);
@@ -217,11 +339,22 @@ QLayer::QLayer(plCreatable* pCre, QWidget* parent)
     miscLayout->addWidget(fMiscFlags[kMiscNoShadowAlpha], 5, 2, 1, 2);
     miscLayout->addItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::MinimumExpanding), 6, 0, 1, 4);
 
+    for (auto cb : fMiscFlags) {
+        cb->setFrom(state.fMiscFlags);
+        connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            plLayer* lay = plLayer::Convert(fCreatable);
+            lay->getState().fMiscFlags |= mask;
+        });
+        connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            plLayer* lay = plLayer::Convert(fCreatable);
+            lay->getState().fMiscFlags &= ~mask;
+        });
+    }
+
     flagTab->addTab(blendWidget, tr("Blend Flags"));
     flagTab->addTab(clampZWidget, tr("Clamp/Z Flags"));
     flagTab->addTab(shadeWidget, tr("Shade Flags"));
     flagTab->addTab(miscWidget, tr("Misc Flags"));
-    updateFlags(lay->getState());
 
     QTabWidget* xformTab = new QTabWidget(this);
     fUvwTransform = new QMatrix44(xformTab);
@@ -316,165 +449,6 @@ void QLayer::saveDamage()
     lay->setOpacity(fOpacity->value());
     lay->setLODBias(fLodBias->value());
     lay->setSpecularPower(fSpecPower->value());
-    updateState(lay->getState());
-}
-
-void QLayer::updateFlags(const hsGMatState& state)
-{
-    fBlendFlags[kBlendTest]->setChecked((state.fBlendFlags & hsGMatState::kBlendTest) != 0);
-    fBlendFlags[kBlendAlpha]->setChecked((state.fBlendFlags & hsGMatState::kBlendAlpha) != 0);
-    fBlendFlags[kBlendMult]->setChecked((state.fBlendFlags & hsGMatState::kBlendMult) != 0);
-    fBlendFlags[kBlendAdd]->setChecked((state.fBlendFlags & hsGMatState::kBlendAdd) != 0);
-    fBlendFlags[kBlendAddColorTimesAlpha]->setChecked((state.fBlendFlags & hsGMatState::kBlendAddColorTimesAlpha) != 0);
-    fBlendFlags[kBlendAntiAlias]->setChecked((state.fBlendFlags & hsGMatState::kBlendAntiAlias) != 0);
-    fBlendFlags[kBlendDetail]->setChecked((state.fBlendFlags & hsGMatState::kBlendDetail) != 0);
-    fBlendFlags[kBlendNoColor]->setChecked((state.fBlendFlags & hsGMatState::kBlendNoColor) != 0);
-    fBlendFlags[kBlendMADD]->setChecked((state.fBlendFlags & hsGMatState::kBlendMADD) != 0);
-    fBlendFlags[kBlendDot3]->setChecked((state.fBlendFlags & hsGMatState::kBlendDot3) != 0);
-    fBlendFlags[kBlendAddSigned]->setChecked((state.fBlendFlags & hsGMatState::kBlendAddSigned) != 0);
-    fBlendFlags[kBlendAddSigned2X]->setChecked((state.fBlendFlags & hsGMatState::kBlendAddSigned2X) != 0);
-    fBlendFlags[kBlendInvertAlpha]->setChecked((state.fBlendFlags & hsGMatState::kBlendInvertAlpha) != 0);
-    fBlendFlags[kBlendInvertColor]->setChecked((state.fBlendFlags & hsGMatState::kBlendInvertColor) != 0);
-    fBlendFlags[kBlendAlphaMult]->setChecked((state.fBlendFlags & hsGMatState::kBlendAlphaMult) != 0);
-    fBlendFlags[kBlendAlphaAdd]->setChecked((state.fBlendFlags & hsGMatState::kBlendAlphaAdd) != 0);
-    fBlendFlags[kBlendNoVtxAlpha]->setChecked((state.fBlendFlags & hsGMatState::kBlendNoVtxAlpha) != 0);
-    fBlendFlags[kBlendNoTexColor]->setChecked((state.fBlendFlags & hsGMatState::kBlendNoTexColor) != 0);
-    fBlendFlags[kBlendNoTexAlpha]->setChecked((state.fBlendFlags & hsGMatState::kBlendNoTexAlpha) != 0);
-    fBlendFlags[kBlendInvertVtxAlpha]->setChecked((state.fBlendFlags & hsGMatState::kBlendInvertVtxAlpha) != 0);
-    fBlendFlags[kBlendAlphaAlways]->setChecked((state.fBlendFlags & hsGMatState::kBlendAlphaAlways) != 0);
-    fBlendFlags[kBlendInvertFinalColor]->setChecked((state.fBlendFlags & hsGMatState::kBlendInvertFinalColor) != 0);
-    fBlendFlags[kBlendInvertFinalAlpha]->setChecked((state.fBlendFlags & hsGMatState::kBlendInvertFinalAlpha) != 0);
-    fBlendFlags[kBlendEnvBumpNext]->setChecked((state.fBlendFlags & hsGMatState::kBlendEnvBumpNext) != 0);
-    fBlendFlags[kBlendSubtract]->setChecked((state.fBlendFlags & hsGMatState::kBlendSubtract) != 0);
-    fBlendFlags[kBlendRevSubtract]->setChecked((state.fBlendFlags & hsGMatState::kBlendRevSubtract) != 0);
-    fBlendFlags[kBlendAlphaTestHigh]->setChecked((state.fBlendFlags & hsGMatState::kBlendAlphaTestHigh) != 0);
-
-    fClampFlags[kClampTextureU]->setChecked((state.fClampFlags & hsGMatState::kClampTextureU) != 0);
-    fClampFlags[kClampTextureV]->setChecked((state.fClampFlags & hsGMatState::kClampTextureV) != 0);
-
-    fZFlags[kZIncLayer]->setChecked((state.fZFlags & hsGMatState::kZIncLayer) != 0);
-    fZFlags[kZClearZ]->setChecked((state.fZFlags & hsGMatState::kZClearZ) != 0);
-    fZFlags[kZNoZRead]->setChecked((state.fZFlags & hsGMatState::kZNoZRead) != 0);
-    fZFlags[kZNoZWrite]->setChecked((state.fZFlags & hsGMatState::kZNoZWrite) != 0);
-    fZFlags[kZLODBias]->setChecked((state.fZFlags & hsGMatState::kZLODBias) != 0);
-
-    fShadeFlags[kShadeSoftShadow]->setChecked((state.fShadeFlags & hsGMatState::kShadeSoftShadow) != 0);
-    fShadeFlags[kShadeNoProjectors]->setChecked((state.fShadeFlags & hsGMatState::kShadeNoProjectors) != 0);
-    fShadeFlags[kShadeEnvironMap]->setChecked((state.fShadeFlags & hsGMatState::kShadeEnvironMap) != 0);
-    fShadeFlags[kShadeVertexShade]->setChecked((state.fShadeFlags & hsGMatState::kShadeVertexShade) != 0);
-    fShadeFlags[kShadeBlack]->setChecked((state.fShadeFlags & hsGMatState::kShadeBlack) != 0);
-    fShadeFlags[kShadeSpecular]->setChecked((state.fShadeFlags & hsGMatState::kShadeSpecular) != 0);
-    fShadeFlags[kShadeNoFog]->setChecked((state.fShadeFlags & hsGMatState::kShadeNoFog) != 0);
-    fShadeFlags[kShadeWhite]->setChecked((state.fShadeFlags & hsGMatState::kShadeWhite) != 0);
-    fShadeFlags[kShadeSpecularAlpha]->setChecked((state.fShadeFlags & hsGMatState::kShadeSpecularAlpha) != 0);
-    fShadeFlags[kShadeSpecularColor]->setChecked((state.fShadeFlags & hsGMatState::kShadeSpecularColor) != 0);
-    fShadeFlags[kShadeSpecularHighlight]->setChecked((state.fShadeFlags & hsGMatState::kShadeSpecularHighlight) != 0);
-    fShadeFlags[kShadeVertColShade]->setChecked((state.fShadeFlags & hsGMatState::kShadeVertColShade) != 0);
-    fShadeFlags[kShadeInherit]->setChecked((state.fShadeFlags & hsGMatState::kShadeInherit) != 0);
-    fShadeFlags[kShadeIgnoreVtxIllum]->setChecked((state.fShadeFlags & hsGMatState::kShadeIgnoreVtxIllum) != 0);
-    fShadeFlags[kShadeEmissive]->setChecked((state.fShadeFlags & hsGMatState::kShadeEmissive) != 0);
-    fShadeFlags[kShadeReallyNoFog]->setChecked((state.fShadeFlags & hsGMatState::kShadeReallyNoFog) != 0);
-
-    fMiscFlags[kMiscWireFrame]->setChecked((state.fMiscFlags & hsGMatState::kMiscWireFrame) != 0);
-    fMiscFlags[kMiscDrawMeshOutlines]->setChecked((state.fMiscFlags & hsGMatState::kMiscDrawMeshOutlines) != 0);
-    fMiscFlags[kMiscTwoSided]->setChecked((state.fMiscFlags & hsGMatState::kMiscTwoSided) != 0);
-    fMiscFlags[kMiscDrawAsSplats]->setChecked((state.fMiscFlags & hsGMatState::kMiscDrawAsSplats) != 0);
-    fMiscFlags[kMiscAdjustPlane]->setChecked((state.fMiscFlags & hsGMatState::kMiscAdjustPlane) != 0);
-    fMiscFlags[kMiscAdjustCylinder]->setChecked((state.fMiscFlags & hsGMatState::kMiscAdjustCylinder) != 0);
-    fMiscFlags[kMiscAdjustSphere]->setChecked((state.fMiscFlags & hsGMatState::kMiscAdjustSphere) != 0);
-    fMiscFlags[kMiscTroubledLoner]->setChecked((state.fMiscFlags & hsGMatState::kMiscTroubledLoner) != 0);
-    fMiscFlags[kMiscBindSkip]->setChecked((state.fMiscFlags & hsGMatState::kMiscBindSkip) != 0);
-    fMiscFlags[kMiscBindMask]->setChecked((state.fMiscFlags & hsGMatState::kMiscBindMask) != 0);
-    fMiscFlags[kMiscBindNext]->setChecked((state.fMiscFlags & hsGMatState::kMiscBindNext) != 0);
-    fMiscFlags[kMiscLightMap]->setChecked((state.fMiscFlags & hsGMatState::kMiscLightMap) != 0);
-    fMiscFlags[kMiscUseReflectionXform]->setChecked((state.fMiscFlags & hsGMatState::kMiscUseReflectionXform) != 0);
-    fMiscFlags[kMiscPerspProjection]->setChecked((state.fMiscFlags & hsGMatState::kMiscPerspProjection) != 0);
-    fMiscFlags[kMiscOrthoProjection]->setChecked((state.fMiscFlags & hsGMatState::kMiscOrthoProjection) != 0);
-    fMiscFlags[kMiscRestartPassHere]->setChecked((state.fMiscFlags & hsGMatState::kMiscRestartPassHere) != 0);
-    fMiscFlags[kMiscBumpLayer]->setChecked((state.fMiscFlags & hsGMatState::kMiscBumpLayer) != 0);
-    fMiscFlags[kMiscBumpDu]->setChecked((state.fMiscFlags & hsGMatState::kMiscBumpDu) != 0);
-    fMiscFlags[kMiscBumpDv]->setChecked((state.fMiscFlags & hsGMatState::kMiscBumpDv) != 0);
-    fMiscFlags[kMiscBumpDw]->setChecked((state.fMiscFlags & hsGMatState::kMiscBumpDw) != 0);
-    fMiscFlags[kMiscNoShadowAlpha]->setChecked((state.fMiscFlags & hsGMatState::kMiscNoShadowAlpha) != 0);
-    fMiscFlags[kMiscUseRefractionXform]->setChecked((state.fMiscFlags & hsGMatState::kMiscUseRefractionXform) != 0);
-    fMiscFlags[kMiscCam2Screen]->setChecked((state.fMiscFlags & hsGMatState::kMiscCam2Screen) != 0);
-}
-
-void QLayer::updateState(hsGMatState& state) const
-{
-    state.fBlendFlags = (fBlendFlags[kBlendTest]->isChecked() ? hsGMatState::kBlendTest : 0)
-                      | (fBlendFlags[kBlendAlpha]->isChecked() ? hsGMatState::kBlendAlpha : 0)
-                      | (fBlendFlags[kBlendMult]->isChecked() ? hsGMatState::kBlendMult : 0)
-                      | (fBlendFlags[kBlendAdd]->isChecked() ? hsGMatState::kBlendAdd : 0)
-                      | (fBlendFlags[kBlendAddColorTimesAlpha]->isChecked() ? hsGMatState::kBlendAddColorTimesAlpha : 0)
-                      | (fBlendFlags[kBlendAntiAlias]->isChecked() ? hsGMatState::kBlendAntiAlias : 0)
-                      | (fBlendFlags[kBlendDetail]->isChecked() ? hsGMatState::kBlendDetail : 0)
-                      | (fBlendFlags[kBlendNoColor]->isChecked() ? hsGMatState::kBlendNoColor : 0)
-                      | (fBlendFlags[kBlendMADD]->isChecked() ? hsGMatState::kBlendMADD : 0)
-                      | (fBlendFlags[kBlendDot3]->isChecked() ? hsGMatState::kBlendDot3 : 0)
-                      | (fBlendFlags[kBlendAddSigned]->isChecked() ? hsGMatState::kBlendAddSigned : 0)
-                      | (fBlendFlags[kBlendAddSigned2X]->isChecked() ? hsGMatState::kBlendAddSigned2X : 0)
-                      | (fBlendFlags[kBlendInvertAlpha]->isChecked() ? hsGMatState::kBlendInvertAlpha : 0)
-                      | (fBlendFlags[kBlendInvertColor]->isChecked() ? hsGMatState::kBlendInvertColor : 0)
-                      | (fBlendFlags[kBlendAlphaMult]->isChecked() ? hsGMatState::kBlendAlphaMult : 0)
-                      | (fBlendFlags[kBlendAlphaAdd]->isChecked() ? hsGMatState::kBlendAlphaAdd : 0)
-                      | (fBlendFlags[kBlendNoVtxAlpha]->isChecked() ? hsGMatState::kBlendNoVtxAlpha : 0)
-                      | (fBlendFlags[kBlendNoTexColor]->isChecked() ? hsGMatState::kBlendNoTexColor : 0)
-                      | (fBlendFlags[kBlendNoTexAlpha]->isChecked() ? hsGMatState::kBlendNoTexAlpha : 0)
-                      | (fBlendFlags[kBlendInvertVtxAlpha]->isChecked() ? hsGMatState::kBlendInvertVtxAlpha : 0)
-                      | (fBlendFlags[kBlendAlphaAlways]->isChecked() ? hsGMatState::kBlendAlphaAlways : 0)
-                      | (fBlendFlags[kBlendInvertFinalColor]->isChecked() ? hsGMatState::kBlendInvertFinalColor : 0)
-                      | (fBlendFlags[kBlendInvertFinalAlpha]->isChecked() ? hsGMatState::kBlendInvertFinalAlpha : 0)
-                      | (fBlendFlags[kBlendEnvBumpNext]->isChecked() ? hsGMatState::kBlendEnvBumpNext : 0)
-                      | (fBlendFlags[kBlendSubtract]->isChecked() ? hsGMatState::kBlendSubtract : 0)
-                      | (fBlendFlags[kBlendRevSubtract]->isChecked() ? hsGMatState::kBlendRevSubtract : 0)
-                      | (fBlendFlags[kBlendAlphaTestHigh]->isChecked() ? hsGMatState::kBlendAlphaTestHigh : 0);
-    state.fClampFlags = (fClampFlags[kClampTextureU]->isChecked() ? hsGMatState::kClampTextureU : 0)
-                      | (fClampFlags[kClampTextureV]->isChecked() ? hsGMatState::kClampTextureV : 0);
-    state.fZFlags = (fZFlags[kZIncLayer]->isChecked() ? hsGMatState::kZIncLayer : 0)
-                  | (fZFlags[kZClearZ]->isChecked() ? hsGMatState::kZClearZ : 0)
-                  | (fZFlags[kZNoZRead]->isChecked() ? hsGMatState::kZNoZRead : 0)
-                  | (fZFlags[kZNoZWrite]->isChecked() ? hsGMatState::kZNoZWrite : 0)
-                  | (fZFlags[kZLODBias]->isChecked() ? hsGMatState::kZLODBias : 0);
-    state.fShadeFlags = (fShadeFlags[kShadeSoftShadow]->isChecked() ? hsGMatState::kShadeSoftShadow : 0)
-                      | (fShadeFlags[kShadeNoProjectors]->isChecked() ? hsGMatState::kShadeNoProjectors : 0)
-                      | (fShadeFlags[kShadeEnvironMap]->isChecked() ? hsGMatState::kShadeEnvironMap : 0)
-                      | (fShadeFlags[kShadeVertexShade]->isChecked() ? hsGMatState::kShadeVertexShade : 0)
-                      | (fShadeFlags[kShadeBlack]->isChecked() ? hsGMatState::kShadeBlack : 0)
-                      | (fShadeFlags[kShadeSpecular]->isChecked() ? hsGMatState::kShadeSpecular : 0)
-                      | (fShadeFlags[kShadeNoFog]->isChecked() ? hsGMatState::kShadeNoFog : 0)
-                      | (fShadeFlags[kShadeWhite]->isChecked() ? hsGMatState::kShadeWhite : 0)
-                      | (fShadeFlags[kShadeSpecularAlpha]->isChecked() ? hsGMatState::kShadeSpecularAlpha : 0)
-                      | (fShadeFlags[kShadeSpecularColor]->isChecked() ? hsGMatState::kShadeSpecularColor : 0)
-                      | (fShadeFlags[kShadeSpecularHighlight]->isChecked() ? hsGMatState::kShadeSpecularHighlight : 0)
-                      | (fShadeFlags[kShadeVertColShade]->isChecked() ? hsGMatState::kShadeVertColShade : 0)
-                      | (fShadeFlags[kShadeInherit]->isChecked() ? hsGMatState::kShadeInherit : 0)
-                      | (fShadeFlags[kShadeIgnoreVtxIllum]->isChecked() ? hsGMatState::kShadeIgnoreVtxIllum : 0)
-                      | (fShadeFlags[kShadeEmissive]->isChecked() ? hsGMatState::kShadeEmissive : 0)
-                      | (fShadeFlags[kShadeReallyNoFog]->isChecked() ? hsGMatState::kShadeReallyNoFog : 0);
-    state.fMiscFlags = (fMiscFlags[kMiscWireFrame]->isChecked() ? hsGMatState::kMiscWireFrame : 0)
-                     | (fMiscFlags[kMiscDrawMeshOutlines]->isChecked() ? hsGMatState::kMiscDrawMeshOutlines : 0)
-                     | (fMiscFlags[kMiscTwoSided]->isChecked() ? hsGMatState::kMiscTwoSided : 0)
-                     | (fMiscFlags[kMiscDrawAsSplats]->isChecked() ? hsGMatState::kMiscDrawAsSplats : 0)
-                     | (fMiscFlags[kMiscAdjustPlane]->isChecked() ? hsGMatState::kMiscAdjustPlane : 0)
-                     | (fMiscFlags[kMiscAdjustCylinder]->isChecked() ? hsGMatState::kMiscAdjustCylinder : 0)
-                     | (fMiscFlags[kMiscAdjustSphere]->isChecked() ? hsGMatState::kMiscAdjustSphere : 0)
-                     | (fMiscFlags[kMiscTroubledLoner]->isChecked() ? hsGMatState::kMiscTroubledLoner : 0)
-                     | (fMiscFlags[kMiscBindSkip]->isChecked() ? hsGMatState::kMiscBindSkip : 0)
-                     | (fMiscFlags[kMiscBindMask]->isChecked() ? hsGMatState::kMiscBindMask : 0)
-                     | (fMiscFlags[kMiscBindNext]->isChecked() ? hsGMatState::kMiscBindNext : 0)
-                     | (fMiscFlags[kMiscLightMap]->isChecked() ? hsGMatState::kMiscLightMap : 0)
-                     | (fMiscFlags[kMiscUseReflectionXform]->isChecked() ? hsGMatState::kMiscUseReflectionXform : 0)
-                     | (fMiscFlags[kMiscPerspProjection]->isChecked() ? hsGMatState::kMiscPerspProjection : 0)
-                     | (fMiscFlags[kMiscOrthoProjection]->isChecked() ? hsGMatState::kMiscOrthoProjection : 0)
-                     | (fMiscFlags[kMiscRestartPassHere]->isChecked() ? hsGMatState::kMiscRestartPassHere : 0)
-                     | (fMiscFlags[kMiscBumpLayer]->isChecked() ? hsGMatState::kMiscBumpLayer : 0)
-                     | (fMiscFlags[kMiscBumpDu]->isChecked() ? hsGMatState::kMiscBumpDu : 0)
-                     | (fMiscFlags[kMiscBumpDv]->isChecked() ? hsGMatState::kMiscBumpDv : 0)
-                     | (fMiscFlags[kMiscBumpDw]->isChecked() ? hsGMatState::kMiscBumpDw : 0)
-                     | (fMiscFlags[kMiscNoShadowAlpha]->isChecked() ? hsGMatState::kMiscNoShadowAlpha : 0)
-                     | (fMiscFlags[kMiscUseRefractionXform]->isChecked() ? hsGMatState::kMiscUseRefractionXform : 0)
-                     | (fMiscFlags[kMiscCam2Screen]->isChecked() ? hsGMatState::kMiscCam2Screen : 0);
 }
 
 void QLayer::setBaseLayer()

--- a/src/PrpShop/PRP/Surface/QLayer.h
+++ b/src/PrpShop/PRP/Surface/QLayer.h
@@ -20,12 +20,12 @@
 #include "PRP/QCreatable.h"
 
 #include <PRP/Surface/plLayer.h>
-#include <QCheckBox>
 #include <QSpinBox>
 #include <QLineEdit>
 #include "PRP/QObjLink.h"
 #include "PRP/QMatrix44.h"
 #include "QColorEdit.h"
+#include "QBitmaskCheckBox.h"
 
 class QLayer : public QCreatable
 {
@@ -58,13 +58,13 @@ protected:
         kBlendInvertFinalColor, kBlendInvertFinalAlpha, kBlendEnvBumpNext,
         kBlendSubtract, kBlendRevSubtract, kBlendAlphaTestHigh, kNumBlendFlags
     };
-    QCheckBox* fBlendFlags[kNumBlendFlags];
+    QBitmaskCheckBox* fBlendFlags[kNumBlendFlags];
 
     enum
     {
         kClampTextureU, kClampTextureV, kNumClampFlags
     };
-    QCheckBox* fClampFlags[kNumClampFlags];
+    QBitmaskCheckBox* fClampFlags[kNumClampFlags];
 
     enum
     {
@@ -74,13 +74,13 @@ protected:
         kShadeSpecularHighlight, kShadeVertColShade, kShadeInherit,
         kShadeIgnoreVtxIllum, kShadeEmissive, kShadeReallyNoFog, kNumShadeFlags
     };
-    QCheckBox* fShadeFlags[kNumShadeFlags];
+    QBitmaskCheckBox* fShadeFlags[kNumShadeFlags];
 
     enum
     {
         kZIncLayer, kZClearZ, kZNoZRead, kZNoZWrite, kZLODBias, kNumZFlags
     };
-    QCheckBox* fZFlags[kNumZFlags];
+    QBitmaskCheckBox* fZFlags[kNumZFlags];
 
     enum
     {
@@ -92,15 +92,11 @@ protected:
         kMiscBumpDv, kMiscBumpDw, kMiscNoShadowAlpha, kMiscUseRefractionXform,
         kMiscCam2Screen, kNumMiscFlags
     };
-    QCheckBox* fMiscFlags[kNumMiscFlags];
+    QBitmaskCheckBox* fMiscFlags[kNumMiscFlags];
 
 public:
     QLayer(plCreatable* pCre, QWidget* parent = NULL);
     void saveDamage() override;
-
-protected:
-    void updateFlags(const hsGMatState& state);
-    void updateState(hsGMatState& state) const;
 
 protected slots:
     void setBaseLayer();

--- a/src/PrpShop/PRP/Surface/QLayerAnimation.h
+++ b/src/PrpShop/PRP/Surface/QLayerAnimation.h
@@ -41,7 +41,6 @@ protected:
 
 public:
     QLayerAnimation(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 
 protected slots:
     void setBaseLayer();

--- a/src/PrpShop/PRP/Surface/QLayerLinkAnimation.cpp
+++ b/src/PrpShop/PRP/Surface/QLayerLinkAnimation.cpp
@@ -36,6 +36,11 @@ QLayerLinkAnimation::QLayerLinkAnimation(plCreatable* pCre, QWidget* parent)
     fLeavingAge = new QCheckBox(tr("Leaving Age"));
     fLeavingAge->setChecked(lay->getLeavingAge());
 
+    connect(fLeavingAge, &QCheckBox::clicked, this, [this](bool checked) {
+        plLayerLinkAnimation* lay = plLayerLinkAnimation::Convert(fCreatable);
+        lay->setLeavingAge(checked);
+    });
+
     QGridLayout* layout = new QGridLayout(this);
     layout->setContentsMargins(8, 8, 8, 8);
     layout->addWidget(fLayerAnimLink, 0, 0, 1, 2);
@@ -45,12 +50,6 @@ QLayerLinkAnimation::QLayerLinkAnimation(plCreatable* pCre, QWidget* parent)
 
     connect(fLinkKey, SIGNAL(addObject()), this, SLOT(setLinkKey()));
     connect(fLinkKey, SIGNAL(delObject()), this, SLOT(unsetLinkKey()));
-}
-
-void QLayerLinkAnimation::saveDamage()
-{
-    plLayerLinkAnimation* lay = plLayerLinkAnimation::Convert(fCreatable);
-    lay->setLeavingAge(fLeavingAge->isChecked());
 }
 
 void QLayerLinkAnimation::setLinkKey()

--- a/src/PrpShop/PRP/Surface/QLayerLinkAnimation.h
+++ b/src/PrpShop/PRP/Surface/QLayerLinkAnimation.h
@@ -34,7 +34,7 @@ protected:
 
 public:
     QLayerLinkAnimation(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
+    void saveDamage() override { }
 
 protected slots:
     void setLinkKey();

--- a/src/PrpShop/PRP/Surface/QLayerLinkAnimation.h
+++ b/src/PrpShop/PRP/Surface/QLayerLinkAnimation.h
@@ -34,7 +34,6 @@ protected:
 
 public:
     QLayerLinkAnimation(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 
 protected slots:
     void setLinkKey();

--- a/src/PrpShop/PRP/Surface/QMaterial.cpp
+++ b/src/PrpShop/PRP/Surface/QMaterial.cpp
@@ -34,20 +34,34 @@ QMaterial::QMaterial(plCreatable* pCre, QWidget* parent)
     QGridLayout* layCompFlags = new QGridLayout(grpCompFlags);
     layCompFlags->setVerticalSpacing(0);
     layCompFlags->setHorizontalSpacing(8);
-    fCBFlags[kCbShaded] = new QCheckBox(tr("Shaded"), grpCompFlags);
-    fCBFlags[kCbEnvironMap] = new QCheckBox(tr("EnvironMap"), grpCompFlags);
-    fCBFlags[kCbProjectOnto] = new QCheckBox(tr("Project Onto"), grpCompFlags);
-    fCBFlags[kCbSoftShadow] = new QCheckBox(tr("Soft Shadow"), grpCompFlags);
-    fCBFlags[kCbSpecular] = new QCheckBox(tr("Specular"), grpCompFlags);
-    fCBFlags[kCbTwoSided] = new QCheckBox(tr("Two-Sided"), grpCompFlags);
-    fCBFlags[kCbDrawAsSplats] = new QCheckBox(tr("Draw as Splats"), grpCompFlags);
-    fCBFlags[kCbAdjusted] = new QCheckBox(tr("Adjusted"), grpCompFlags);
-    fCBFlags[kCbNoSoftShadow] = new QCheckBox(tr("No Soft Shadow"), grpCompFlags);
-    fCBFlags[kCbDynamic] = new QCheckBox(tr("Dynamic"), grpCompFlags);
-    fCBFlags[kCbDecal] = new QCheckBox(tr("Decal"), grpCompFlags);
-    fCBFlags[kCbIsEmissive] = new QCheckBox(tr("Is Emissive"), grpCompFlags);
-    fCBFlags[kCbIsLightMapped] = new QCheckBox(tr("Is Light Mapped"), grpCompFlags);
-    fCBFlags[kCbNeedsBlendChannel] = new QCheckBox(tr("Needs Blend Channel"), grpCompFlags);
+    fCBFlags[kCbShaded] = new QBitmaskCheckBox(hsGMaterial::kCompShaded,
+            tr("Shaded"), grpCompFlags);
+    fCBFlags[kCbEnvironMap] = new QBitmaskCheckBox(hsGMaterial::kCompEnvironMap,
+            tr("EnvironMap"), grpCompFlags);
+    fCBFlags[kCbProjectOnto] = new QBitmaskCheckBox(hsGMaterial::kCompProjectOnto,
+            tr("Project Onto"), grpCompFlags);
+    fCBFlags[kCbSoftShadow] = new QBitmaskCheckBox(hsGMaterial::kCompSoftShadow,
+            tr("Soft Shadow"), grpCompFlags);
+    fCBFlags[kCbSpecular] = new QBitmaskCheckBox(hsGMaterial::kCompSpecular,
+            tr("Specular"), grpCompFlags);
+    fCBFlags[kCbTwoSided] = new QBitmaskCheckBox(hsGMaterial::kCompTwoSided,
+            tr("Two-Sided"), grpCompFlags);
+    fCBFlags[kCbDrawAsSplats] = new QBitmaskCheckBox(hsGMaterial::kCompDrawAsSplats,
+            tr("Draw as Splats"), grpCompFlags);
+    fCBFlags[kCbAdjusted] = new QBitmaskCheckBox(hsGMaterial::kCompAdjusted,
+            tr("Adjusted"), grpCompFlags);
+    fCBFlags[kCbNoSoftShadow] = new QBitmaskCheckBox(hsGMaterial::kCompNoSoftShadow,
+            tr("No Soft Shadow"), grpCompFlags);
+    fCBFlags[kCbDynamic] = new QBitmaskCheckBox(hsGMaterial::kCompDynamic,
+            tr("Dynamic"), grpCompFlags);
+    fCBFlags[kCbDecal] = new QBitmaskCheckBox(hsGMaterial::kCompDecal,
+            tr("Decal"), grpCompFlags);
+    fCBFlags[kCbIsEmissive] = new QBitmaskCheckBox(hsGMaterial::kCompIsEmissive,
+            tr("Is Emissive"), grpCompFlags);
+    fCBFlags[kCbIsLightMapped] = new QBitmaskCheckBox(hsGMaterial::kCompIsLightMapped,
+            tr("Is Light Mapped"), grpCompFlags);
+    fCBFlags[kCbNeedsBlendChannel] = new QBitmaskCheckBox(hsGMaterial::kCompNeedsBlendChannel,
+            tr("Needs Blend Channel"), grpCompFlags);
     layCompFlags->addWidget(fCBFlags[kCbShaded], 0, 0);
     layCompFlags->addWidget(fCBFlags[kCbTwoSided], 0, 1);
     layCompFlags->addWidget(fCBFlags[kCbDrawAsSplats], 0, 2);
@@ -62,20 +76,18 @@ QMaterial::QMaterial(plCreatable* pCre, QWidget* parent)
     layCompFlags->addWidget(fCBFlags[kCbNeedsBlendChannel], 3, 2);
     layCompFlags->addWidget(fCBFlags[kCbSpecular], 4, 0);
     layCompFlags->addWidget(fCBFlags[kCbIsEmissive], 4, 1);
-    fCBFlags[kCbShaded]->setChecked(mat->getCompFlags() & hsGMaterial::kCompShaded);
-    fCBFlags[kCbEnvironMap]->setChecked(mat->getCompFlags() & hsGMaterial::kCompEnvironMap);
-    fCBFlags[kCbProjectOnto]->setChecked(mat->getCompFlags() & hsGMaterial::kCompProjectOnto);
-    fCBFlags[kCbSoftShadow]->setChecked(mat->getCompFlags() & hsGMaterial::kCompSoftShadow);
-    fCBFlags[kCbSpecular]->setChecked(mat->getCompFlags() & hsGMaterial::kCompSpecular);
-    fCBFlags[kCbTwoSided]->setChecked(mat->getCompFlags() & hsGMaterial::kCompTwoSided);
-    fCBFlags[kCbDrawAsSplats]->setChecked(mat->getCompFlags() & hsGMaterial::kCompDrawAsSplats);
-    fCBFlags[kCbAdjusted]->setChecked(mat->getCompFlags() & hsGMaterial::kCompAdjusted);
-    fCBFlags[kCbNoSoftShadow]->setChecked(mat->getCompFlags() & hsGMaterial::kCompNoSoftShadow);
-    fCBFlags[kCbDynamic]->setChecked(mat->getCompFlags() & hsGMaterial::kCompDynamic);
-    fCBFlags[kCbDecal]->setChecked(mat->getCompFlags() & hsGMaterial::kCompDecal);
-    fCBFlags[kCbIsEmissive]->setChecked(mat->getCompFlags() & hsGMaterial::kCompIsEmissive);
-    fCBFlags[kCbIsLightMapped]->setChecked(mat->getCompFlags() & hsGMaterial::kCompIsLightMapped);
-    fCBFlags[kCbNeedsBlendChannel]->setChecked(mat->getCompFlags() & hsGMaterial::kCompNeedsBlendChannel);
+
+    for (auto cb : fCBFlags) {
+        cb->setFrom(mat->getCompFlags());
+        connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            hsGMaterial* mat = hsGMaterial::Convert(fCreatable);
+            mat->setCompFlags(mat->getCompFlags() | mask);
+        });
+        connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            hsGMaterial* mat = hsGMaterial::Convert(fCreatable);
+            mat->setCompFlags(mat->getCompFlags() & ~mask);
+        });
+    }
 
     QTabWidget* objTab = new QTabWidget(this);
     fLayers = new QKeyList(mat->getKey(), objTab);
@@ -99,21 +111,6 @@ QMaterial::QMaterial(plCreatable* pCre, QWidget* parent)
 void QMaterial::saveDamage()
 {
     hsGMaterial* mat = hsGMaterial::Convert(fCreatable);
-
-    mat->setCompFlags((fCBFlags[kCbShaded]->isChecked() ? hsGMaterial::kCompShaded : 0)
-                    | (fCBFlags[kCbEnvironMap]->isChecked() ? hsGMaterial::kCompEnvironMap : 0)
-                    | (fCBFlags[kCbProjectOnto]->isChecked() ? hsGMaterial::kCompProjectOnto : 0)
-                    | (fCBFlags[kCbSoftShadow]->isChecked() ? hsGMaterial::kCompSoftShadow : 0)
-                    | (fCBFlags[kCbSpecular]->isChecked() ? hsGMaterial::kCompSpecular : 0)
-                    | (fCBFlags[kCbTwoSided]->isChecked() ? hsGMaterial::kCompTwoSided : 0)
-                    | (fCBFlags[kCbDrawAsSplats]->isChecked() ? hsGMaterial::kCompDrawAsSplats : 0)
-                    | (fCBFlags[kCbAdjusted]->isChecked() ? hsGMaterial::kCompAdjusted : 0)
-                    | (fCBFlags[kCbNoSoftShadow]->isChecked() ? hsGMaterial::kCompNoSoftShadow : 0)
-                    | (fCBFlags[kCbDynamic]->isChecked() ? hsGMaterial::kCompDynamic : 0)
-                    | (fCBFlags[kCbDecal]->isChecked() ? hsGMaterial::kCompDecal : 0)
-                    | (fCBFlags[kCbIsEmissive]->isChecked() ? hsGMaterial::kCompIsEmissive : 0)
-                    | (fCBFlags[kCbIsLightMapped]->isChecked() ? hsGMaterial::kCompIsLightMapped : 0)
-                    | (fCBFlags[kCbNeedsBlendChannel]->isChecked() ? hsGMaterial::kCompNeedsBlendChannel : 0));
 
     mat->clearLayers();
     QList<plKey> layers = fLayers->keys();

--- a/src/PrpShop/PRP/Surface/QMaterial.h
+++ b/src/PrpShop/PRP/Surface/QMaterial.h
@@ -20,9 +20,9 @@
 #include "PRP/QCreatable.h"
 
 #include <PRP/Surface/hsGMaterial.h>
-#include <QCheckBox>
 #include "PRP/QObjLink.h"
 #include "PRP/QKeyList.h"
+#include "QBitmaskCheckBox.h"
 
 class QMaterial : public QCreatable
 {
@@ -38,7 +38,7 @@ protected:
     };
 
     QCreatableLink* fSynchObjLink;
-    QCheckBox* fCBFlags[kNumCompFlags];
+    QBitmaskCheckBox* fCBFlags[kNumCompFlags];
     QKeyList* fLayers;
     QKeyList* fPiggyBacks;
 

--- a/src/PrpShop/PRP/Surface/QMipmap.cpp
+++ b/src/PrpShop/PRP/Surface/QMipmap.cpp
@@ -217,22 +217,38 @@ QMipmap::QMipmap(plCreatable* pCre, QWidget* parent)
     QGridLayout* layFlags = new QGridLayout(grpFlags);
     layFlags->setVerticalSpacing(0);
     layFlags->setHorizontalSpacing(8);
-    fFlags[kAlphaChannelFlag] = new QCheckBox(tr("Alpha Channel"), grpFlags);
-    fFlags[kAlphaBitFlag] = new QCheckBox(tr("Alpha Bit"), grpFlags);
-    fFlags[kBumpEnvMap] = new QCheckBox(tr("Bump Env Map"), grpFlags);
-    fFlags[kForce32Bit] = new QCheckBox(tr("Force 32-bit"), grpFlags);
-    fFlags[kDontThrowAwayImage] = new QCheckBox(tr("Don't Throw Away"), grpFlags);
-    fFlags[kForceOneMipLevel] = new QCheckBox(tr("Force One Level"), grpFlags);
-    fFlags[kNoMaxSize] = new QCheckBox(tr("No Maximum Size"), grpFlags);
-    fFlags[kIntensityMap] = new QCheckBox(tr("Intensity Map"), grpFlags);
-    fFlags[kHalfSize] = new QCheckBox(tr("Half Size"), grpFlags);
-    fFlags[kUserOwnsBitmap] = new QCheckBox(tr("User Owned"), grpFlags);
-    fFlags[kForceRewrite] = new QCheckBox(tr("Force Rewrite"), grpFlags);
-    fFlags[kForceNonCompressed] = new QCheckBox(tr("Force Non-compressed"), grpFlags);
-    fFlags[kIsTexture] = new QCheckBox(tr("Is Texture"), grpFlags);
-    fFlags[kIsOffscreen] = new QCheckBox(tr("Is Offscreen"), grpFlags);
-    fFlags[kIsProjected] = new QCheckBox(tr("Is Projected"), grpFlags);
-    fFlags[kIsOrtho] = new QCheckBox(tr("Is Orthogonal"), grpFlags);
+    fFlags[kAlphaChannelFlag] = new QBitmaskCheckBox(plBitmap::kAlphaChannelFlag,
+            tr("Alpha Channel"), grpFlags);
+    fFlags[kAlphaBitFlag] = new QBitmaskCheckBox(plBitmap::kAlphaBitFlag,
+            tr("Alpha Bit"), grpFlags);
+    fFlags[kBumpEnvMap] = new QBitmaskCheckBox(plBitmap::kBumpEnvMap,
+            tr("Bump Env Map"), grpFlags);
+    fFlags[kForce32Bit] = new QBitmaskCheckBox(plBitmap::kForce32Bit,
+            tr("Force 32-bit"), grpFlags);
+    fFlags[kDontThrowAwayImage] = new QBitmaskCheckBox(plBitmap::kDontThrowAwayImage,
+            tr("Don't Throw Away"), grpFlags);
+    fFlags[kForceOneMipLevel] = new QBitmaskCheckBox(plBitmap::kForceOneMipLevel,
+            tr("Force One Level"), grpFlags);
+    fFlags[kNoMaxSize] = new QBitmaskCheckBox(plBitmap::kNoMaxSize,
+            tr("No Maximum Size"), grpFlags);
+    fFlags[kIntensityMap] = new QBitmaskCheckBox(plBitmap::kIntensityMap,
+            tr("Intensity Map"), grpFlags);
+    fFlags[kHalfSize] = new QBitmaskCheckBox(plBitmap::kHalfSize,
+            tr("Half Size"), grpFlags);
+    fFlags[kUserOwnsBitmap] = new QBitmaskCheckBox(plBitmap::kUserOwnsBitmap,
+            tr("User Owned"), grpFlags);
+    fFlags[kForceRewrite] = new QBitmaskCheckBox(plBitmap::kForceRewrite,
+            tr("Force Rewrite"), grpFlags);
+    fFlags[kForceNonCompressed] = new QBitmaskCheckBox(plBitmap::kForceNonCompressed,
+            tr("Force Non-compressed"), grpFlags);
+    fFlags[kIsTexture] = new QBitmaskCheckBox(plBitmap::kIsTexture,
+            tr("Is Texture"), grpFlags);
+    fFlags[kIsOffscreen] = new QBitmaskCheckBox(plBitmap::kIsOffscreen,
+            tr("Is Offscreen"), grpFlags);
+    fFlags[kIsProjected] = new QBitmaskCheckBox(plBitmap::kIsProjected,
+            tr("Is Projected"), grpFlags);
+    fFlags[kIsOrtho] = new QBitmaskCheckBox(plBitmap::kIsOrtho,
+            tr("Is Orthogonal"), grpFlags);
     layFlags->addWidget(fFlags[kAlphaChannelFlag], 0, 0);
     layFlags->addWidget(fFlags[kAlphaBitFlag], 1, 0);
     layFlags->addWidget(fFlags[kBumpEnvMap], 2, 0);
@@ -249,22 +265,18 @@ QMipmap::QMipmap(plCreatable* pCre, QWidget* parent)
     layFlags->addWidget(fFlags[kIsOffscreen], 1, 3);
     layFlags->addWidget(fFlags[kIsProjected], 2, 3);
     layFlags->addWidget(fFlags[kIsOrtho], 3, 3);
-    fFlags[kAlphaChannelFlag]->setChecked(tex->getFlags() & plBitmap::kAlphaChannelFlag);
-    fFlags[kAlphaBitFlag]->setChecked(tex->getFlags() & plBitmap::kAlphaBitFlag);
-    fFlags[kBumpEnvMap]->setChecked(tex->getFlags() & plBitmap::kBumpEnvMap);
-    fFlags[kForce32Bit]->setChecked(tex->getFlags() & plBitmap::kForce32Bit);
-    fFlags[kDontThrowAwayImage]->setChecked(tex->getFlags() & plBitmap::kDontThrowAwayImage);
-    fFlags[kForceOneMipLevel]->setChecked(tex->getFlags() & plBitmap::kForceOneMipLevel);
-    fFlags[kNoMaxSize]->setChecked(tex->getFlags() & plBitmap::kNoMaxSize);
-    fFlags[kIntensityMap]->setChecked(tex->getFlags() & plBitmap::kIntensityMap);
-    fFlags[kHalfSize]->setChecked(tex->getFlags() & plBitmap::kHalfSize);
-    fFlags[kUserOwnsBitmap]->setChecked(tex->getFlags() & plBitmap::kUserOwnsBitmap);
-    fFlags[kForceRewrite]->setChecked(tex->getFlags() & plBitmap::kForceRewrite);
-    fFlags[kForceNonCompressed]->setChecked(tex->getFlags() & plBitmap::kForceNonCompressed);
-    fFlags[kIsTexture]->setChecked(tex->getFlags() & plBitmap::kIsTexture);
-    fFlags[kIsOffscreen]->setChecked(tex->getFlags() & plBitmap::kIsOffscreen);
-    fFlags[kIsProjected]->setChecked(tex->getFlags() & plBitmap::kIsProjected);
-    fFlags[kIsOrtho]->setChecked(tex->getFlags() & plBitmap::kIsOrtho);
+
+    for (auto cb : fFlags) {
+        cb->setFrom(tex->getFlags());
+        connect(cb, &QBitmaskCheckBox::setBits, this, [this](unsigned int mask) {
+            plMipmap* tex = plMipmap::Convert(fCreatable);
+            tex->setFlags(tex->getFlags() | mask);
+        });
+        connect(cb, &QBitmaskCheckBox::unsetBits, this, [this](unsigned int mask) {
+            plMipmap* tex = plMipmap::Convert(fCreatable);
+            tex->setFlags(tex->getFlags() & ~mask);
+        });
+    }
 
     QGroupBox* grpProps = new QGroupBox(tr("Texture Propreties"), this);
     QGridLayout* layProps = new QGridLayout(grpProps);
@@ -312,28 +324,6 @@ QMipmap::QMipmap(plCreatable* pCre, QWidget* parent)
     connect(xJPGLink, SIGNAL(activated()), this, SLOT(onExportJPEG()));
     connect(iDDSLink, SIGNAL(activated()), this, SLOT(onImportDDS()));
     connect(iJPGLink, SIGNAL(activated()), this, SLOT(onImportJPEG()));
-}
-
-void QMipmap::saveDamage()
-{
-    plMipmap* tex = plMipmap::Convert(fCreatable);
-
-    tex->setFlags((fFlags[kAlphaChannelFlag]->isChecked() ? plBitmap::kAlphaChannelFlag : 0)
-                | (fFlags[kAlphaBitFlag]->isChecked() ? plBitmap::kAlphaBitFlag : 0)
-                | (fFlags[kBumpEnvMap]->isChecked() ? plBitmap::kBumpEnvMap : 0)
-                | (fFlags[kForce32Bit]->isChecked() ? plBitmap::kForce32Bit : 0)
-                | (fFlags[kDontThrowAwayImage]->isChecked() ? plBitmap::kDontThrowAwayImage : 0)
-                | (fFlags[kForceOneMipLevel]->isChecked() ? plBitmap::kForceOneMipLevel : 0)
-                | (fFlags[kNoMaxSize]->isChecked() ? plBitmap::kNoMaxSize : 0)
-                | (fFlags[kIntensityMap]->isChecked() ? plBitmap::kIntensityMap : 0)
-                | (fFlags[kHalfSize]->isChecked() ? plBitmap::kHalfSize : 0)
-                | (fFlags[kUserOwnsBitmap]->isChecked() ? plBitmap::kUserOwnsBitmap : 0)
-                | (fFlags[kForceRewrite]->isChecked() ? plBitmap::kForceRewrite : 0)
-                | (fFlags[kForceNonCompressed]->isChecked() ? plBitmap::kForceNonCompressed : 0)
-                | (fFlags[kIsTexture]->isChecked() ? plBitmap::kIsTexture : 0)
-                | (fFlags[kIsOffscreen]->isChecked() ? plBitmap::kIsOffscreen : 0)
-                | (fFlags[kIsProjected]->isChecked() ? plBitmap::kIsProjected : 0)
-                | (fFlags[kIsOrtho]->isChecked() ? plBitmap::kIsOrtho : 0));
 }
 
 static void makeJColorSurface(const plMipmap* tex, hsStream* S)

--- a/src/PrpShop/PRP/Surface/QMipmap.h
+++ b/src/PrpShop/PRP/Surface/QMipmap.h
@@ -60,7 +60,6 @@ protected:
 
 public:
     QMipmap_Preview(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 
     int level() const { return fLevel; }
 
@@ -85,7 +84,6 @@ protected:
 
 public:
     QMipmap(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 
 private slots:
     void onExportDDS();

--- a/src/PrpShop/PRP/Surface/QMipmap.h
+++ b/src/PrpShop/PRP/Surface/QMipmap.h
@@ -18,11 +18,12 @@
 #define _QMIPMAP_H
 
 #include "PRP/QCreatable.h"
-#include "PRP/QObjLink.h"
-#include <QImage>
-#include <QCheckBox>
-#include <QSpinBox>
+
 #include <PRP/Surface/plMipmap.h>
+#include <QImage>
+#include <QSpinBox>
+#include "PRP/QObjLink.h"
+#include "QBitmaskCheckBox.h"
 
 class QTextureBox : public QWidget
 {
@@ -79,12 +80,12 @@ protected:
         kHalfSize, kUserOwnsBitmap, kForceRewrite, kForceNonCompressed,
         kIsTexture, kIsOffscreen, kIsProjected, kIsOrtho, kNumBitmapFlags
     };
-    QCheckBox* fFlags[kNumBitmapFlags];
+    QBitmaskCheckBox* fFlags[kNumBitmapFlags];
     QCreatableLink* fPreviewLink;
 
 public:
     QMipmap(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
+    void saveDamage() override { }
 
 private slots:
     void onExportDDS();

--- a/src/PrpShop/QBitmaskCheckBox.cpp
+++ b/src/PrpShop/QBitmaskCheckBox.cpp
@@ -14,39 +14,16 @@
  * along with PlasmaShop.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _QSOUNDBUFFER_H
-#define _QSOUNDBUFFER_H
-
-#include "PRP/QCreatable.h"
-
-#include <PRP/Audio/plSoundBuffer.h>
-#include <QComboBox>
-#include <QSpinBox>
 #include "QBitmaskCheckBox.h"
 
-class QSoundBuffer : public QCreatable
+QBitmaskCheckBox::QBitmaskCheckBox(unsigned int value, const QString& text,
+                                   QWidget* parent)
+    : QCheckBox(text, parent), fBitMask(value)
 {
-    Q_OBJECT
-
-protected:
-    enum
-    {
-        kIsExternal, kAlwaysExternal, kOnlyLeftChannel, kOnlyRightChannel,
-        kStreamCompressed, kNumFlags
-    };
-    QBitmaskCheckBox* fFlags[kNumFlags];
-
-    QLineEdit* fFilename;
-    QComboBox* fFormat;
-    QSpinBox* fNumChannels;
-    QIntEdit* fBlockAlign;
-    QIntEdit* fBitRate;
-    QIntEdit* fSampleRate;
-    QIntEdit* fAvgBytesPerSec;
-
-public:
-    QSoundBuffer(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
-};
-
-#endif
+    connect(this, &QAbstractButton::clicked, this, [this](bool checked) {
+        if (checked)
+            emit setBits(fBitMask);
+        else
+            emit unsetBits(fBitMask);
+    });
+}

--- a/src/PrpShop/QBitmaskCheckBox.h
+++ b/src/PrpShop/QBitmaskCheckBox.h
@@ -14,39 +14,29 @@
  * along with PlasmaShop.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _QSOUNDBUFFER_H
-#define _QSOUNDBUFFER_H
+#ifndef _QBITMASKCHECKBOX_H
+#define _QBITMASKCHECKBOX_H
 
-#include "PRP/QCreatable.h"
+#include <QCheckBox>
 
-#include <PRP/Audio/plSoundBuffer.h>
-#include <QComboBox>
-#include <QSpinBox>
-#include "QBitmaskCheckBox.h"
-
-class QSoundBuffer : public QCreatable
+class QBitmaskCheckBox : public QCheckBox
 {
     Q_OBJECT
 
-protected:
-    enum
-    {
-        kIsExternal, kAlwaysExternal, kOnlyLeftChannel, kOnlyRightChannel,
-        kStreamCompressed, kNumFlags
-    };
-    QBitmaskCheckBox* fFlags[kNumFlags];
-
-    QLineEdit* fFilename;
-    QComboBox* fFormat;
-    QSpinBox* fNumChannels;
-    QIntEdit* fBlockAlign;
-    QIntEdit* fBitRate;
-    QIntEdit* fSampleRate;
-    QIntEdit* fAvgBytesPerSec;
-
 public:
-    QSoundBuffer(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override;
+    QBitmaskCheckBox(unsigned int value, const QString& text, QWidget* parent = nullptr);
+
+    void setFrom(unsigned int value)
+    {
+        setChecked((value & fBitMask) == fBitMask);
+    }
+
+signals:
+    void setBits(unsigned int mask);
+    void unsetBits(unsigned int mask);
+
+private:
+    unsigned int fBitMask;
 };
 
-#endif
+#endif // _QBITMASKCHECKBOX_H

--- a/src/PrpShop/QHexViewer.h
+++ b/src/PrpShop/QHexViewer.h
@@ -41,7 +41,6 @@ protected:
 
 public:
     QHexViewer(plCreatable* pCre, QWidget* parent = Q_NULLPTR);
-    void saveDamage() Q_DECL_OVERRIDE { }   // Read-only viewer
 
     void loadObject(const QString& filename, uint32_t offset, uint32_t size);
 

--- a/src/PrpShop/QPrcEditor.h
+++ b/src/PrpShop/QPrcEditor.h
@@ -38,7 +38,6 @@ protected:
 
 public:
     explicit QPrcEditor(plCreatable* pCre, QWidget* parent = Q_NULLPTR);
-    void saveDamage() Q_DECL_OVERRIDE { }   // Handled in compilation
 
     QSize sizeHint() const Q_DECL_OVERRIDE;
 

--- a/src/PrpShop/QTargetList.h
+++ b/src/PrpShop/QTargetList.h
@@ -31,7 +31,6 @@ protected:
 
 public:
     QTargetList(plCreatable* pCre, QWidget* parent = NULL);
-    void saveDamage() override { }
 };
 
 #endif


### PR DESCRIPTION
The eventual goal is to eliminate most of the need for `saveDamage()`, which can cause inconsistent views and often adds extra complexity to the forms.