### PR TITLE
PlasmaShop font editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,7 @@ endif()
 
 find_package(HSPlasma REQUIRED)
 find_package(string_theory 2.0 REQUIRED)
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Gui REQUIRED)
-find_package(Qt5Widgets REQUIRED)
+find_package(Qt5 5.5 REQUIRED COMPONENTS Core Gui Widgets)
 find_package(KF5SyntaxHighlighting REQUIRED)
 find_package(PythonInterp REQUIRED)
 

--- a/src/PlasmaShop/CMakeLists.txt
+++ b/src/PlasmaShop/CMakeLists.txt
@@ -6,6 +6,7 @@ set(PlasmaShop_Headers
     NewFile.h
     QPlasmaDevModeDat.h
     QPlasmaDocument.h
+    QPlasmaFont.h
     QPlasmaTextDoc.h
     QPlasmaSumFile.h
     QPlasmaPakFile.h
@@ -19,6 +20,7 @@ set(PlasmaShop_Sources
     NewFile.cpp
     QPlasmaDevModeDat.cpp
     QPlasmaDocument.cpp
+    QPlasmaFont.cpp
     QPlasmaTextDoc.cpp
     QPlasmaSumFile.cpp
     QPlasmaPakFile.cpp

--- a/src/PlasmaShop/QPlasmaDevModeDat.cpp
+++ b/src/PlasmaShop/QPlasmaDevModeDat.cpp
@@ -130,7 +130,7 @@ QPlasmaDevModeDat::QPlasmaDevModeDat(QWidget* parent)
     setLayout(scrollLayout);
 }
 
-bool QPlasmaDevModeDat::loadFile(QString filename)
+bool QPlasmaDevModeDat::loadFile(const QString& filename)
 {
     hsFileStream S;
     if (!S.open(filename.toUtf8().data(), fmRead))
@@ -140,7 +140,7 @@ bool QPlasmaDevModeDat::loadFile(QString filename)
     return QPlasmaDocument::loadFile(filename);
 }
 
-bool QPlasmaDevModeDat::saveTo(QString filename)
+bool QPlasmaDevModeDat::saveTo(const QString& filename)
 {
     hsFileStream S;
     S.open(filename.toUtf8().data(), fmCreate);

--- a/src/PlasmaShop/QPlasmaDevModeDat.h
+++ b/src/PlasmaShop/QPlasmaDevModeDat.h
@@ -33,8 +33,8 @@ class QPlasmaDevModeDat : public QPlasmaDocument
 public:
     QPlasmaDevModeDat(QWidget* parent);
 
-    bool loadFile(QString filename) override;
-    bool saveTo(QString filename) override;
+    bool loadFile(const QString& filename) override;
+    bool saveTo(const QString& filename) override;
 
 private:
     enum //DeviceRecord Labels

--- a/src/PlasmaShop/QPlasmaDocument.cpp
+++ b/src/PlasmaShop/QPlasmaDocument.cpp
@@ -16,6 +16,7 @@
 
 #include "QPlasmaDevModeDat.h"
 #include "QPlasmaDocument.h"
+#include "QPlasmaFont.h"
 #include "QPlasmaTextDoc.h"
 #include "QPlasmaSumFile.h"
 #include "QPlasmaPakFile.h"
@@ -23,7 +24,7 @@
 #include <QSettings>
 #include <QMessageBox>
 
-QIcon QPlasmaDocument::GetDocIcon(QString filename)
+QIcon QPlasmaDocument::GetDocIcon(const QString& filename)
 {
     // Check for special types first
     if (filename.startsWith('<')) {
@@ -100,7 +101,7 @@ QPlasmaDocument* QPlasmaDocument::GetEditor(DocumentType docType, QWidget* paren
     case kDocDevMode:
         return new QPlasmaDevModeDat(parent);
     case kDocFont:
-        // TODO: Implement
+        return new QPlasmaFont(parent);
     default:
         return NULL;
     }
@@ -147,7 +148,7 @@ bool QPlasmaDocument::GetEncryptionKeyFromUser(QWidget* parent, unsigned int* ke
     return true;
 }
 
-bool QPlasmaDocument::loadFile(QString filename)
+bool QPlasmaDocument::loadFile(const QString& filename)
 {
     fFilename = filename;
     fPersistDirty = false;
@@ -155,7 +156,7 @@ bool QPlasmaDocument::loadFile(QString filename)
     return true;
 }
 
-bool QPlasmaDocument::saveTo(QString filename)
+bool QPlasmaDocument::saveTo(const QString& filename)
 {
     fFilename = filename;
     fPersistDirty = false;

--- a/src/PlasmaShop/QPlasmaDocument.h
+++ b/src/PlasmaShop/QPlasmaDocument.h
@@ -37,7 +37,7 @@ public:
     };
 
 public:
-    static QIcon GetDocIcon(QString filename);
+    static QIcon GetDocIcon(const QString& filename);
     static QPlasmaDocument* GetEditor(DocumentType docType, QWidget* parent);
     static bool GetEncryptionKeyFromUser(QWidget* parent, unsigned int* key);
 
@@ -49,7 +49,7 @@ public:
     bool isDirty() const { return fDirty; }
 
     QString filename() const { return fFilename; }
-    void setFilename(QString filename) { fFilename = filename; }
+    void setFilename(QString filename) { fFilename = std::move(filename); }
 
     virtual bool canCut() const { return false; }
     virtual bool canCopy() const { return false; }
@@ -59,8 +59,8 @@ public:
     virtual bool canUndo() const { return false; }
     virtual bool canRedo() const { return false; }
 
-    virtual bool loadFile(QString filename);
-    virtual bool saveTo(QString filename);
+    virtual bool loadFile(const QString& filename);
+    virtual bool saveTo(const QString& filename);
     bool saveDefault() { return saveTo(fFilename); }
     bool revert() { return loadFile(fFilename); }
 

--- a/src/PlasmaShop/QPlasmaFont.cpp
+++ b/src/PlasmaShop/QPlasmaFont.cpp
@@ -1,0 +1,176 @@
+/* This file is part of PlasmaShop.
+ *
+ * PlasmaShop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlasmaShop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PlasmaShop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "QPlasmaFont.h"
+#include "QPlasma.h"
+
+#include <Stream/hsRAMStream.h>
+#include <QLabel>
+#include <QLineEdit>
+#include <QSpinBox>
+#include <QCheckBox>
+#include <QScrollBar>
+#include <QGridLayout>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QMessageBox>
+
+/* QPlasmaCharWidget */
+QPlasmaCharWidget::QPlasmaCharWidget(QWidget* parent)
+    : QAbstractScrollArea(parent), fFont()
+{
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+}
+
+void QPlasmaCharWidget::reloadFont()
+{
+    // Recompute layout
+    const QSize viewportSize = viewport()->size();
+    const size_t charsPerLine = viewportSize.width() / (fFont->getWidth() + 1);
+    const size_t lines = (fFont->getNumCharacters() + (charsPerLine - 1)) / charsPerLine;
+    const size_t totalHeight = lines * (fFont->getMaxCharHeight() + 1);
+    verticalScrollBar()->setRange(0, totalHeight - viewportSize.height());
+    verticalScrollBar()->setPageStep(fFont->getMaxCharHeight() * 2);
+    verticalScrollBar()->setSingleStep(fFont->getMaxCharHeight() / 2);
+}
+
+void QPlasmaCharWidget::paintEvent(QPaintEvent* event)
+{
+    QPainter painter(viewport());
+    QPalette pal = palette();
+    painter.fillRect(event->rect(), pal.brush(QPalette::Base));
+    if (!fFont)
+        return;
+
+    QImage::Format imgFormat;
+    switch (fFont->getBPP()) {
+    case 1:
+        imgFormat = QImage::Format_Mono;
+        break;
+    case 8:
+        imgFormat = QImage::Format_Alpha8;
+        break;
+    default:
+        QMessageBox::critical(this, tr("Error"), tr("Unsupported bitmap format"));
+        return;
+    }
+
+    painter.setPen(pal.color(QPalette::Midlight));
+
+    const QSize viewportSize = viewport()->size();
+    const size_t charsPerLine = viewportSize.width() / (fFont->getWidth() + 1);
+    const size_t stride = fFont->getStride();
+    for (size_t c = 0; c < fFont->getNumCharacters(); ++c) {
+        QRect rGlyph((c % charsPerLine) * (fFont->getWidth() + 1),
+                     (c / charsPerLine) * (fFont->getMaxCharHeight() + 1),
+                     fFont->getWidth(), fFont->getMaxCharHeight());
+        rGlyph.translate(0, -verticalScrollBar()->value());
+
+        const plFont::plCharacter& ch = fFont->getCharacter(c);
+        QImage cimg(fFont->getGlyph(c), fFont->getWidth(), ch.getHeight(),
+                    stride, imgFormat);
+        painter.drawImage(rGlyph.topLeft(), cimg);
+        painter.drawLine(rGlyph.right() + 1, rGlyph.top(),
+                         rGlyph.right() + 1, rGlyph.bottom() + 1);
+        painter.drawLine(rGlyph.left(), rGlyph.bottom() + 1,
+                         rGlyph.right() + 1, rGlyph.bottom() + 1);
+    }
+}
+
+void QPlasmaCharWidget::resizeEvent(QResizeEvent *event)
+{
+    (void)event;
+    reloadFont();
+}
+
+
+/* QPlasmaFont */
+QPlasmaFont::QPlasmaFont(QWidget* parent)
+    : QPlasmaDocument(kDocFont, parent)
+{
+    auto lblName = new QLabel(tr("&Face:"), this);
+    fFontName = new QLineEdit(this);
+    lblName->setBuddy(fFontName);
+
+    auto lblSize = new QLabel(tr("&Size:"), this);
+    fFontSize = new QSpinBox(this);
+    fFontSize->setMinimum(0);
+    fFontSize->setMaximum(255);
+    lblSize->setBuddy(fFontSize);
+
+    fBold = new QCheckBox(tr("&Bold"), this);
+    fItalic = new QCheckBox(tr("&Italic"), this);
+
+    fChars = new QPlasmaCharWidget(this);
+    fChars->setRenderFont(&fFont);
+
+    auto layout = new QGridLayout(this);
+    layout->setContentsMargins(4, 4, 4, 4);
+    layout->addWidget(lblName, 0, 0);
+    layout->addWidget(fFontName, 0, 1, 1, 5);
+    layout->addWidget(lblSize, 1, 0);
+    layout->addWidget(fFontSize, 1, 1);
+    layout->addItem(new QSpacerItem(10, 0), 1, 2);
+    layout->addWidget(fBold, 1, 3);
+    layout->addWidget(fItalic, 1, 4);
+    layout->addItem(new QSpacerItem(0, 0, QSizePolicy::Expanding), 1, 5);
+    layout->addWidget(fChars, 2, 0, 1, 6);
+    setLayout(layout);
+
+    connect(fFontName, &QLineEdit::textEdited, this, &QPlasmaDocument::makeDirty);
+    connect(fFontSize, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, [this] { makeDirty(); });
+    connect(fBold, &QCheckBox::clicked, this, &QPlasmaDocument::makeDirty);
+    connect(fItalic, &QCheckBox::clicked, this, &QPlasmaDocument::makeDirty);
+}
+
+bool QPlasmaFont::loadFile(const QString& filename)
+{
+    ST::string st_filename = qstr2st(filename);
+    hsFileStream S;
+    if (!S.open(st_filename, fmRead)) {
+        QMessageBox::critical(this, tr("Error"), tr("Failed to open %1 for reading").arg(filename));
+        return false;
+    }
+
+    fFont.readP2F(&S);
+    fFontName->setText(st2qstr(fFont.getName()));
+    fFontSize->setValue(fFont.getSize());
+    fBold->setChecked(fFont.isBold());
+    fItalic->setChecked(fFont.isItalic());
+    fChars->reloadFont();
+
+    return QPlasmaDocument::loadFile(filename);
+}
+
+bool QPlasmaFont::saveTo(const QString& filename)
+{
+    ST::string st_filename = qstr2st(filename);
+    hsFileStream S;
+    if (!S.open(st_filename, fmCreate)) {
+        QMessageBox::critical(this, tr("Error"), tr("Failed to open %1 for writing").arg(filename));
+        return false;
+    }
+
+    fFont.setName(qstr2st(fFontName->text()));
+    fFont.setSize(fFontSize->value());
+    fFont.setBold(fBold->isChecked());
+    fFont.setItalic(fItalic->isChecked());
+    fFont.writeP2F(&S);
+
+    return QPlasmaDocument::saveTo(filename);
+}

--- a/src/PlasmaShop/QPlasmaFont.h
+++ b/src/PlasmaShop/QPlasmaFont.h
@@ -36,12 +36,42 @@ public:
     void setRenderFont(plFont* font) { fFont = font; }
     void reloadFont();
 
+signals:
+    void characterSelected(int which);
+
 protected:
     void paintEvent(QPaintEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+
+    void focusInEvent(QFocusEvent*) override { viewport()->update(); }
+    void focusOutEvent(QFocusEvent*) override { viewport()->update(); }
 
 private:
     plFont* fFont;
+    int fSelected;
+    int fCharsPerLine;
+};
+
+class QPlasmaCharRender : public QWidget
+{
+    Q_OBJECT
+
+public:
+    QPlasmaCharRender(QWidget* parent);
+
+    void setRenderFont(plFont* font) { fFont = font; }
+    void reloadFont();
+
+    void setCharacter(int which);
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+private:
+    plFont* fFont;
+    int fCharIdx;
 };
 
 class QPlasmaFont : public QPlasmaDocument
@@ -54,6 +84,9 @@ public:
     bool loadFile(const QString& filename) override;
     bool saveTo(const QString& filename) override;
 
+public slots:
+    void showCharacter(int which);
+
 private:
     plFont fFont;
     QLineEdit* fFontName;
@@ -61,6 +94,7 @@ private:
     QCheckBox* fBold;
     QCheckBox* fItalic;
     QPlasmaCharWidget* fChars;
+    QPlasmaCharRender* fRender;
 };
 
 #endif

--- a/src/PlasmaShop/QPlasmaFont.h
+++ b/src/PlasmaShop/QPlasmaFont.h
@@ -14,46 +14,53 @@
  * along with PlasmaShop.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _QPLASMASUMFILE_H
-#define _QPLASMASUMFILE_H
+#ifndef _QPLASMAFONT_H
+#define _QPLASMAFONT_H
 
 #include "QPlasmaDocument.h"
-#include <Stream/hsStream.h>
-#include <Util/hsSumFile.h>
-#include <QTreeWidget>
-#include <QAction>
-#include <vector>
+#include <PRP/Surface/plFont.h>
 
-class QPlasmaSumFile : public QPlasmaDocument
+#include <QAbstractScrollArea>
+
+class QLineEdit;
+class QSpinBox;
+class QCheckBox;
+
+class QPlasmaCharWidget : public QAbstractScrollArea
 {
     Q_OBJECT
 
 public:
-    QPlasmaSumFile(QWidget* parent);
+    explicit QPlasmaCharWidget(QWidget *parent);
+
+    void setRenderFont(plFont* font) { fFont = font; }
+    void reloadFont();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
+
+private:
+    plFont* fFont;
+};
+
+class QPlasmaFont : public QPlasmaDocument
+{
+    Q_OBJECT
+
+public:
+    explicit QPlasmaFont(QWidget* parent);
 
     bool loadFile(const QString& filename) override;
     bool saveTo(const QString& filename) override;
 
 private:
-    QTreeWidget* fFileList;
-    hsSumFile fSumData;
-
-    enum
-    {
-        kAUpdate, kAAdd, kADel, kANumActions
-    };
-    QAction* fActions[kANumActions];
-
-    bool loadSumData(hsStream* S);
-    bool saveSumData(hsStream* S);
-    void addToSumFile(const QString& filename);
-
-private slots:
-    void onContextMenu(QPoint pos);
-    void onItemChanged(QTreeWidgetItem* item, int column);
-    void onUpdate();
-    void onAdd();
-    void onDel();
+    plFont fFont;
+    QLineEdit* fFontName;
+    QSpinBox* fFontSize;
+    QCheckBox* fBold;
+    QCheckBox* fItalic;
+    QPlasmaCharWidget* fChars;
 };
 
 #endif

--- a/src/PlasmaShop/QPlasmaFont.h
+++ b/src/PlasmaShop/QPlasmaFont.h
@@ -24,7 +24,9 @@
 
 class QLineEdit;
 class QSpinBox;
+class QDoubleSpinBox;
 class QCheckBox;
+class QGroupBox;
 
 class QPlasmaCharWidget : public QAbstractScrollArea
 {
@@ -86,6 +88,7 @@ public:
 
 public slots:
     void showCharacter(int which);
+    void updateCharacter();
 
 private:
     plFont fFont;
@@ -94,7 +97,14 @@ private:
     QCheckBox* fBold;
     QCheckBox* fItalic;
     QPlasmaCharWidget* fChars;
+
+    int fCharacter;
+    QGroupBox* fCharDetail;
     QPlasmaCharRender* fRender;
+    QDoubleSpinBox* fLeftKern;
+    QDoubleSpinBox* fRightKern;
+    QSpinBox* fBaseLine;
+    bool fBlockSpinBoxes;
 };
 
 #endif

--- a/src/PlasmaShop/QPlasmaPakFile.cpp
+++ b/src/PlasmaShop/QPlasmaPakFile.cpp
@@ -293,7 +293,7 @@ QPlasmaPakFile::QPlasmaPakFile(QWidget* parent)
     connect(fActions[kExtractAll], SIGNAL(triggered()), this, SLOT(onExtractAll()));
 }
 
-bool QPlasmaPakFile::loadFile(QString filename)
+bool QPlasmaPakFile::loadFile(const QString& filename)
 {
     if (plEncryptedStream::IsFileEncrypted(filename.toUtf8().data())) {
         plEncryptedStream S(PlasmaVer::pvPrime);
@@ -323,7 +323,7 @@ bool QPlasmaPakFile::loadFile(QString filename)
     return QPlasmaDocument::loadFile(filename);
 }
 
-bool QPlasmaPakFile::saveTo(QString filename)
+bool QPlasmaPakFile::saveTo(const QString& filename)
 {
     if (fEncryption == kEncNone) {
         hsFileStream S(PlasmaVer::pvMoul);

--- a/src/PlasmaShop/QPlasmaPakFile.h
+++ b/src/PlasmaShop/QPlasmaPakFile.h
@@ -112,8 +112,8 @@ public:
     
     QPlasmaPakFile(QWidget* parent);
 
-    bool loadFile(QString filename) override;
-    bool saveTo(QString filename) override;
+    bool loadFile(const QString& filename) override;
+    bool saveTo(const QString& filename) override;
 
     void setPackageType(PlasmaPackage::PackageType type)
     {

--- a/src/PlasmaShop/QPlasmaSumFile.cpp
+++ b/src/PlasmaShop/QPlasmaSumFile.cpp
@@ -113,7 +113,7 @@ QPlasmaSumFile::QPlasmaSumFile(QWidget* parent)
     connect(fActions[kADel], &QAction::triggered, this, &QPlasmaSumFile::onDel);
 }
 
-bool QPlasmaSumFile::loadFile(QString filename)
+bool QPlasmaSumFile::loadFile(const QString& filename)
 {
     ST::string st_filename = qstr2st(filename);
     if (plEncryptedStream::IsFileEncrypted(st_filename)) {
@@ -145,7 +145,7 @@ bool QPlasmaSumFile::loadFile(QString filename)
     return QPlasmaDocument::loadFile(filename);
 }
 
-bool QPlasmaSumFile::saveTo(QString filename)
+bool QPlasmaSumFile::saveTo(const QString& filename)
 {
     ST::string st_filename = qstr2st(filename);
     if (fEncryption == kEncNone) {

--- a/src/PlasmaShop/QPlasmaTextDoc.cpp
+++ b/src/PlasmaShop/QPlasmaTextDoc.cpp
@@ -445,7 +445,7 @@ bool QPlasmaTextDoc::onReplaceAll(const QString& text, bool regex, bool cs,
     return true;
 }
 
-bool QPlasmaTextDoc::loadFile(QString filename)
+bool QPlasmaTextDoc::loadFile(const QString& filename)
 {
     const ST::string stFilename = qstr2st(filename);
     if (filename.right(4).toLower() == ".elf") {
@@ -491,7 +491,7 @@ static QString unixToWindowsText(QString &&text)
     return text.replace("\n", "\r\n").replace("\r\r\n", "\r\n");
 }
 
-bool QPlasmaTextDoc::saveTo(QString filename)
+bool QPlasmaTextDoc::saveTo(const QString& filename)
 {
     const ST::string stFilename = qstr2st(filename);
     if (fEncryption == kEncNone) {

--- a/src/PlasmaShop/QPlasmaTextDoc.h
+++ b/src/PlasmaShop/QPlasmaTextDoc.h
@@ -52,8 +52,8 @@ public:
     bool canUndo() const Q_DECL_OVERRIDE { return fEditor->document()->isUndoAvailable(); }
     bool canRedo() const Q_DECL_OVERRIDE { return fEditor->document()->isRedoAvailable(); }
 
-    bool loadFile(QString filename) Q_DECL_OVERRIDE;
-    bool saveTo(QString filename) Q_DECL_OVERRIDE;
+    bool loadFile(const QString& filename) Q_DECL_OVERRIDE;
+    bool saveTo(const QString& filename) Q_DECL_OVERRIDE;
 
     void setSyntax(SyntaxMode syn);
     void setEncoding(EncodingMode type);


### PR DESCRIPTION
This adds back a Font (p2f) editor for PlasmaShop, which has been missing since the ancient 1.x versions...

This does not (yet) support adding or replacing the glyph images yet, but it does support tweaking font and character metadata and full character set preview that PS 1.x had.

![image](https://user-images.githubusercontent.com/714191/69261264-21d6e780-0b76-11ea-9ab0-9a01a762f2bd.png)
