### PR TITLE
CI

### DIFF
--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -1,0 +1,46 @@
+name: Linux-CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install -y libkf5syntaxhighlighting-dev ninja-build qtbase5-dev
+
+      - name: Checkout string_theory
+        uses: actions/checkout@v2
+        with:
+          repository: zrax/string_theory
+          path: string_theory
+      - name: Build string_theory
+        run: |
+          mkdir -p string_theory/build && cd string_theory/build
+          cmake -GNinja -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/build_deps/prefix" \
+            -DCMAKE_BUILD_TYPE=Release -DST_BUILD_TESTS=OFF ..
+          cmake --build .
+          cmake --build . --target install
+
+      - name: Checkout HSPlasma
+        uses: actions/checkout@v2
+        with:
+          repository: H-uru/libhsplasma
+          path: libhsplasma
+      - name: Build HSPlasma
+        run: |
+          mkdir -p libhsplasma/build && cd libhsplasma/build
+          cmake -GNinja -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/build_deps/prefix" \
+            -DENABLE_PYTHON=OFF -DENABLE_TOOLS=OFF -DENABLE_NET=OFF -DENABLE_PHYSX=OFF ..
+          cmake --build .
+          cmake --build . --target install
+
+      - name: Build PlasmaShop
+        run: |
+          mkdir build && cd build
+          cmake -GNinja -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/build_deps/prefix" ..
+          cmake --build .

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -1,0 +1,170 @@
+name: Windows-CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        arch: ["x86", "x64"]
+        kf5: ["v5.70.0"]
+        qt: ["5.15.0"]
+
+    env:
+      CMAKE_GENERATOR: Visual Studio 16 2019
+      vcpkg-triplet: ${{ matrix.arch }}-windows-static-md
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Bootstrap vcpkg
+        id: bootstrap-vcpkg
+        run: |
+          cd C:\vcpkg
+          git pull
+          Write-Host "::set-output name=vcpkg-rev::$(git rev-parse HEAD)"
+          ./bootstrap-vcpkg.bat
+
+      - name: Restore Dependency Cache
+        id: cache-vcpkg
+        uses: actions/cache@v1
+        with:
+          path: C:\vcpkg\installed
+          key: |
+            vcpkg-triplet=${{ env.vcpkg-triplet }} vcpkg-response=${{ hashFiles('vcpkg.txt') }} vcpkg-rev=${{ steps.bootstrap-vcpkg.outputs.vcpkg-rev }}
+          restore-keys: |
+            vcpkg-triplet=${{ env.vcpkg-triplet }} vcpkg-response=${{ hashFiles('vcpkg.txt') }}
+            vcpkg-triplet=${{ env.vcpkg-triplet }}
+
+      - name: Upgrade Dependencies
+        if: steps.cache-vcpkg.outputs.cache-hit == 'true'
+        run: |
+          vcpkg upgrade --no-dry-run --triplet ${{ env.vcpkg-triplet }}
+
+      - name: Build Dependencies
+        run: |
+          vcpkg install `@vcpkg.txt --triplet ${{ env.vcpkg-triplet }}
+          vcpkg list --x-full-desc
+
+      - name: Configure Platform Arch
+        run: |
+          # Qt started providing both x86 and x64 builds for only MSVC 2019 as of 5.15. This was
+          # true only for MSVC 2017 before then.
+          [int[]]$qt_ver = "${{ matrix.qt }}".split('.')
+          if (($qt_ver[0] -eq 5) -and ($qt_ver[1] -lt 15)) {
+            $qt_compiler = "msvc2017"
+          } else {
+            $qt_compiler = "msvc2019"
+          }
+
+          if ("${{ matrix.arch }}" -eq "x86") {
+            $cmake_arch = "Win32"
+            $qt_arch = "win32_$($qt_compiler)"
+          } else {
+            $cmake_arch = "${{ matrix.arch }}"
+            $qt_arch = "win64_$($qt_compiler)_64"
+          }
+          Write-Host "::set-env name=CMAKE_GENERATOR_PLATFORM::$cmake_arch"
+          Write-Host "::set-env name=QT_ARCH::$qt_arch"
+
+      # Qt5 takes roughly a thousand years to build, so we download it from elsehwere...
+      - name: Restore Qt Cache
+        id: cache-qt
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace }}\qt
+          key: os=${{ runner.os }} qt=${{ matrix.qt }} arch=${{ env.qt_arch }}
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2
+        with:
+          arch: ${{ env.QT_ARCH }}
+          version: ${{ matrix.qt }}
+          dir: ${{ github.workspace }}\qt
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          aqtversion: ==0.9.*
+
+      # KF5SyntaxHighlighting and ecm release in lock-step
+      - name: Checkout ECM
+        uses: actions/checkout@v2
+        with:
+          repository: KDE/extra-cmake-modules
+          path: ecm
+          ref: ${{ matrix.kf5 }}
+      - name: Build ECM
+        run: |
+          cd ecm
+          mkdir build && cd build
+          cmake `
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\install `
+            -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF `
+            ..
+          cmake --build . --config Release -j 2
+          cmake --build . --config Release --target INSTALL
+
+      # Build KF5SyntaxHighlighting manually due to Qt dependency...
+      - name: Checkout KF5SyntaxHighlighting
+        uses: actions/checkout@v2
+        with:
+          repository: KDE/syntax-highlighting
+          path: syntax-highlighting
+          ref: ${{ matrix.kf5 }}
+
+      - uses: shogo82148/actions-setup-perl@v1
+      - name: Build KF5SyntaxHighlighting
+        run: |
+          cd syntax-highlighting
+          mkdir build && cd build
+          cmake `
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\install `
+            -DBUILD_HTML_DOCS=OFF -DBUILD_MAN_DOCS=OFF -DBUILD_QTHELP_DOCS=OFF -DBUILD_TESTING=OFF `
+            ..
+          cmake --build . --config Release -j 2
+          cmake --build . --config Release --target INSTALL
+
+      - name: Checkout HSPlasma
+        uses: actions/checkout@v2
+        with:
+          repository: H-uru/libhsplasma
+          path: libhsplasma
+
+      - name: Build libHSPlasma
+        run: |
+          cd libhsplasma
+          mkdir build && cd build
+          cmake `
+            -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake `
+            -DVCPKG_TARGET_TRIPLET=${{ env.vcpkg-triplet }} `
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\install `
+            -DENABLE_PYTHON=OFF -DENABLE_TOOLS=OFF -DENABLE_NET=OFF -DENABLE_PHYSX=OFF ..
+          cmake --build . --config Release -j 2
+          cmake --build . --config Release --target INSTALL
+
+      - name: Build PlasmaShop
+        run: |
+          mkdir build && cd build
+          cmake `
+            -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake `
+            -DVCPKG_TARGET_TRIPLET=${{ env.vcpkg-triplet }} `
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}\install `
+            ..
+          cmake --build . --config Release -j 2
+          cmake --build . --config Release --target INSTALL
+
+      - name: Deploy Qt
+        run: |
+          cd ${{ env.Qt5_Dir }}\bin
+          $ExeFiles = Get-ChildItem "${{ github.workspace }}\install\bin" -Filter *.exe
+          $DllFiles = Get-ChildItem "${{ github.workspace }}\install\bin" -Filter *.dll
+          ForEach-Object -InputObject ($ExeFiles + $DllFiles) {
+            ./windeployqt.exe --release $_.FullName
+          }
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ runner.os }}-${{ matrix.arch }}-qt${{ matrix.qt }}
+          path: install\bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(PlasmaShop)
 cmake_minimum_required(VERSION 3.1)
+project(PlasmaShop)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/PlasmaShop/CMakeLists.txt
+++ b/src/PlasmaShop/CMakeLists.txt
@@ -124,7 +124,7 @@ add_executable(PlasmaShop WIN32 MACOSX_BUNDLE
                ${PlasmaShop_Headers} ${PlasmaShop_Sources}
                ${pycdc_Headers} ${pycdc_Sources} ${pycdc_GeneratedSources}
                ${PlasmaShop_RCC})
-target_link_libraries(PlasmaShop PSCommon Qt5::Widgets KF5::SyntaxHighlighting)
+target_link_libraries(PlasmaShop PSCommon Qt5::Core Qt5::Widgets KF5::SyntaxHighlighting)
 target_link_libraries(PlasmaShop HSPlasma)
 
 if(WIN32)

--- a/src/PrpShop/CMakeLists.txt
+++ b/src/PrpShop/CMakeLists.txt
@@ -153,7 +153,7 @@ set(QT_QTOPENGL_LIB_DEPENDENCIES ${OPENGL_glu_LIBRARY} ${OPENGL_gl_LIBRARY})
 
 add_executable(PrpShop WIN32 MACOSX_BUNDLE
                ${PrpShop_Sources} ${PrpShop_Headers} ${PrpShop_RCC})
-target_link_libraries(PrpShop PSCommon Qt5::Widgets Qt5::OpenGL)
+target_link_libraries(PrpShop PSCommon Qt5::Core Qt5::Widgets Qt5::OpenGL)
 target_link_libraries(PrpShop KF5::SyntaxHighlighting HSPlasma)
 target_link_libraries(PrpShop ${QT_QTOPENGL_LIB_DEPENDENCIES})
 

--- a/src/VaultShop/CMakeLists.txt
+++ b/src/VaultShop/CMakeLists.txt
@@ -41,7 +41,7 @@ qt5_add_resources(VaultShop_RCC images.qrc)
 
 add_executable(VaultShop WIN32 MACOSX_BUNDLE
                ${VaultShop_Sources} ${VaultShop_Headers} ${VaultShop_RCC})
-target_link_libraries(VaultShop PSCommon Qt5::Widgets)
+target_link_libraries(VaultShop PSCommon Qt5::Core Qt5::Widgets)
 target_link_libraries(VaultShop HSPlasma)
 
 if(APPLE)

--- a/vcpkg.txt
+++ b/vcpkg.txt
@@ -1,0 +1,4 @@
+libjpeg-turbo
+libpng
+string-theory
+zlib


### PR DESCRIPTION
This adds Windows and Linux/gcc CI based on GitHub Actions. Windows-CI uploads functioning packages for x86 and x64. I thought that building the installer would be slightly outside the scope of this PR and elected to not implement that.

Windows-CI exposed, and I fixed, a linker error in which WinMain was undefined on Windows when using the v141 toolchain, CMake 3.17, and Qt 5.12. ~CMake spat out a load of warnings about policy `CMP0020` not being defined and defaulting to `OLD`. Supposedly, setting this policy to `NEW` would also fix the issue. However, in my experience, `cmake_policy(SET CMP0020 NEW)` had no effect on either fixing the warnings or the linker error.~

Windows-CI could be sped up fairly significantly if a vcpkg port is ever added for libHSPlasma :wink: