### PR TITLE
Massively improve ELF loading performance

### DIFF
--- a/src/PlasmaShop/QPlasmaTextDoc.cpp
+++ b/src/PlasmaShop/QPlasmaTextDoc.cpp
@@ -446,9 +446,11 @@ bool QPlasmaTextDoc::loadFile(const QString& filename)
         hsElfStream S;
         if (!S.open(stFilename, fmRead))
             return false;
-        fEditor->clear();
+        QString logAccum;
+        logAccum.reserve(static_cast<int>(S.size()));
         while (!S.eof())
-            fEditor->appendPlainText(st2qstr(S.readLine() + "\n"));
+            logAccum.append(st2qstr(S.readLine() + '\n'));
+        fEditor->setPlainText(logAccum);
         fEditor->setReadOnly(true);
     } else if (plEncryptedStream::IsFileEncrypted(stFilename)) {
         plEncryptedStream S(PlasmaVer::pvUnknown);


### PR DESCRIPTION
Massively improve ELF loading performance by pre-loading the file content instead of repeatedly appending to the widget's live document.

This also fixes the extra newline appearing after every ELF line.