### PR TITLE
Update pycdc to latest master.

### DIFF
--- a/src/PlasmaShop/CMakeLists.txt
+++ b/src/PlasmaShop/CMakeLists.txt
@@ -76,6 +76,9 @@ set(pycdc_Maps
     ${pycdc_SOURCE_DIR}/bytes/python_35.map
     ${pycdc_SOURCE_DIR}/bytes/python_36.map
     ${pycdc_SOURCE_DIR}/bytes/python_37.map
+    ${pycdc_SOURCE_DIR}/bytes/python_38.map
+    ${pycdc_SOURCE_DIR}/bytes/python_39.map
+    ${pycdc_SOURCE_DIR}/bytes/python_310.map
 )
 set(pycdc_GeneratedSources
     ${pycdc_BINARY_DIR}/bytes/python_10.cpp
@@ -100,6 +103,9 @@ set(pycdc_GeneratedSources
     ${pycdc_BINARY_DIR}/bytes/python_35.cpp
     ${pycdc_BINARY_DIR}/bytes/python_36.cpp
     ${pycdc_BINARY_DIR}/bytes/python_37.cpp
+    ${pycdc_BINARY_DIR}/bytes/python_38.cpp
+    ${pycdc_BINARY_DIR}/bytes/python_39.cpp
+    ${pycdc_BINARY_DIR}/bytes/python_310.cpp
 )
 # run "comp_map.py" in the pycdc folder to generate the source code
 add_custom_target(create-bytes-source-dir ALL


### PR DESCRIPTION
This pulls in several fixes, both for build-time issues and for decompyler results.