### PR TITLE
Fix Window Close action being ignored.

### DIFF
--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -91,6 +91,7 @@ PrpShopMain::PrpShopMain()
     fActions[kFileSaveAs]->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_S);
     fActions[kFileExit]->setShortcut(Qt::ALT + Qt::Key_F4);
     fActions[kWindowClose]->setShortcut(Qt::CTRL + Qt::Key_W);
+    fActions[kWindowClose]->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     fActions[kToolsProperties]->setCheckable(true);
     fActions[kToolsProperties]->setChecked(true);
     fActions[kToolsShowTypeIDs]->setCheckable(true);
@@ -151,6 +152,7 @@ PrpShopMain::PrpShopMain()
     fBrowserTree->setUniformRowHeights(true);
     fBrowserTree->setHeaderHidden(true);
     fBrowserTree->setContextMenuPolicy(Qt::CustomContextMenu);
+    fBrowserTree->addAction(fActions[kWindowClose]);
     addDockWidget(Qt::LeftDockWidgetArea, fBrowserDock);
 
     // Property Pane


### PR DESCRIPTION
Fixes #41.

The Window Close action needs its context set in order to apply to the window and its subchildren.  Adding it as an action to the Tree as well will close windows as expected even if the tree is currently the active widget.