### PR TITLE
Allow displaying age/page and object IDs in Object Browser tree

### DIFF
--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -68,6 +68,7 @@ PrpShopMain::PrpShopMain()
     fActions[kFileExit] = new QAction(tr("E&xit"), this);
     fActions[kToolsProperties] = new QAction(tr("Show &Properties Pane"), this);
     fActions[kToolsShowTypeIDs] = new QAction(tr("Show Type &IDs"), this);
+    fActions[kToolsShowObjectIDs] = new QAction(tr("Show &Object IDs"), this);
     fActions[kToolsNewObject] = new QAction(tr("&New Object..."), this);
     fActions[kWindowPrev] = new QAction(tr("&Previous"), this);
     fActions[kWindowNext] = new QAction(tr("&Next"), this);
@@ -98,6 +99,8 @@ PrpShopMain::PrpShopMain()
     fActions[kToolsProperties]->setChecked(true);
     fActions[kToolsShowTypeIDs]->setCheckable(true);
     fActions[kToolsShowTypeIDs]->setChecked(false);
+    fActions[kToolsShowObjectIDs]->setCheckable(true);
+    fActions[kToolsShowObjectIDs]->setChecked(false);
 
     // Main Menus
     QMenu* fileMenu = menuBar()->addMenu(tr("&File"));
@@ -112,6 +115,7 @@ PrpShopMain::PrpShopMain()
     QMenu* viewMenu = menuBar()->addMenu(tr("&Tools"));
     viewMenu->addAction(fActions[kToolsProperties]);
     viewMenu->addAction(fActions[kToolsShowTypeIDs]);
+    viewMenu->addAction(fActions[kToolsShowObjectIDs]);
     viewMenu->addSeparator();
     viewMenu->addAction(fActions[kToolsNewObject]);
 
@@ -182,6 +186,8 @@ PrpShopMain::PrpShopMain()
             fActions[kToolsProperties], &QAction::setChecked);
     connect(fActions[kToolsShowTypeIDs], &QAction::toggled,
             this, &PrpShopMain::showTypeIDs);
+    connect(fActions[kToolsShowObjectIDs], &QAction::toggled,
+            this, &PrpShopMain::showObjectIDs);
     connect(fActions[kToolsNewObject], &QAction::triggered,
             this, &PrpShopMain::createNewObject);
 
@@ -233,6 +239,8 @@ PrpShopMain::PrpShopMain()
 
     fActions[kToolsShowTypeIDs]->setChecked(
             settings.value("ShowTypeIDs", false).toBool());
+    fActions[kToolsShowObjectIDs]->setChecked(
+            settings.value("ShowObjectIDs", false).toBool());
 }
 
 void PrpShopMain::closeEvent(QCloseEvent*)
@@ -249,6 +257,7 @@ void PrpShopMain::closeEvent(QCloseEvent*)
 
     settings.setValue("DialogDir", fDialogDir);
     settings.setValue("ShowTypeIDs", s_showTypeIDs);
+    settings.setValue("ShowObjectIDs", s_showObjectIDs);
 }
 
 void PrpShopMain::dragEnterEvent(QDragEnterEvent* evt)
@@ -1192,6 +1201,27 @@ void PrpShopMain::showTypeIDs(bool show)
                 typeNode->setText(0, pqGetFriendlyClassName(type));
             }
             pageNode->sortChildren(0, Qt::AscendingOrder);
+        }
+    }
+}
+
+void PrpShopMain::showObjectIDs(bool show)
+{
+    s_showObjectIDs = show;
+
+    // Refresh the folder display for currently loaded pages
+    for (int i=0; i<fBrowserTree->topLevelItemCount(); i++) {
+        QPlasmaTreeItem* ageNode = (QPlasmaTreeItem*)fBrowserTree->topLevelItem(i);
+        for (int j=0; j<ageNode->childCount(); j++) {
+            QPlasmaTreeItem* pageNode = (QPlasmaTreeItem*)ageNode->child(j);
+            for (int t=0; t<pageNode->childCount(); t++) {
+                QPlasmaTreeItem* typeNode = (QPlasmaTreeItem*)pageNode->child(t);
+                for (int o=0; o<typeNode->childCount(); o++) {
+                    QPlasmaTreeItem* objectNode = (QPlasmaTreeItem*)typeNode->child(o);
+                    objectNode->setText(0, pqFormatKeyName(objectNode->obj()->getKey()));
+                }
+                typeNode->sortChildren(0, Qt::AscendingOrder);
+            }
         }
     }
 }

--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -1218,7 +1218,7 @@ void PrpShopMain::showObjectIDs(bool show)
                 QPlasmaTreeItem* typeNode = (QPlasmaTreeItem*)pageNode->child(t);
                 for (int o=0; o<typeNode->childCount(); o++) {
                     QPlasmaTreeItem* objectNode = (QPlasmaTreeItem*)typeNode->child(o);
-                    objectNode->setText(0, pqFormatKeyName(objectNode->obj()->getKey()));
+                    objectNode->reinit();
                 }
                 typeNode->sortChildren(0, Qt::AscendingOrder);
             }

--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -595,10 +595,10 @@ QPlasmaTreeItem* PrpShopMain::ensurePath(const plLocation& loc, short objType)
     plPageInfo* page = fResMgr.FindPage(loc);
     QPlasmaTreeItem* ageItem = NULL;
     QString ageName = st2qstr(page->getAge());
-    QString pageName = st2qstr(page->getPage());
     for (int i=0; i<fBrowserTree->topLevelItemCount(); i++) {
-        if (fBrowserTree->topLevelItem(i)->text(0) == ageName) {
-            ageItem = (QPlasmaTreeItem*)fBrowserTree->topLevelItem(i);
+        auto topLevelItem = static_cast<QPlasmaTreeItem*>(fBrowserTree->topLevelItem(i));
+        if (topLevelItem->age() == ageName) {
+            ageItem = topLevelItem;
             break;
         }
     }
@@ -607,8 +607,9 @@ QPlasmaTreeItem* PrpShopMain::ensurePath(const plLocation& loc, short objType)
 
     QPlasmaTreeItem* pageItem = NULL;
     for (int i=0; i<ageItem->childCount(); i++) {
-        if (ageItem->child(i)->text(0) == pageName) {
-            pageItem = (QPlasmaTreeItem*)ageItem->child(i);
+        auto child = static_cast<QPlasmaTreeItem*>(ageItem->child(i));
+        if (child->page()->getLocation() == loc) {
+            pageItem = child;
             break;
         }
     }
@@ -1106,8 +1107,9 @@ QPlasmaTreeItem* PrpShopMain::loadPage(plPageInfo* page, QString filename)
         // Find or create the Age folder
         QString ageName = st2qstr(page->getAge());
         for (int i=0; i<fBrowserTree->topLevelItemCount(); i++) {
-            if (fBrowserTree->topLevelItem(i)->text(0) == ageName) {
-                parent = (QPlasmaTreeItem*)fBrowserTree->topLevelItem(i);
+            auto topLevelItem = static_cast<QPlasmaTreeItem*>(fBrowserTree->topLevelItem(i));
+            if (topLevelItem->age() == ageName) {
+                parent = topLevelItem;
                 break;
             }
         }

--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -344,6 +344,7 @@ void PrpShopMain::setPropertyPage(PropWhich which)
             fLoadMaskQ[1] = new QSpinBox(group);
             fLoadMaskQ[0]->setRange(0, 255);
             fLoadMaskQ[1]->setRange(0, 255);
+            fObjId = new QLabel(group);
 
             fCloneIdBox = new QGroupBox(tr("Clone IDs"), group);
             fCloneIdBox->setCheckable(true);
@@ -364,7 +365,9 @@ void PrpShopMain::setPropertyPage(PropWhich which)
             layout->addWidget(new QLabel(tr("Load Mask:"), group), 2, 0);
             layout->addWidget(fLoadMaskQ[0], 2, 1);
             layout->addWidget(fLoadMaskQ[1], 2, 2);
-            layout->addWidget(fCloneIdBox, 3, 0, 1, 3);
+            layout->addWidget(new QLabel(tr("Object ID:"), group), 3, 0);
+            layout->addWidget(fObjId, 3, 1, 1, 2);
+            layout->addWidget(fCloneIdBox, 4, 0, 1, 3);
         }
         break;
     default:
@@ -408,6 +411,7 @@ void PrpShopMain::treeItemChanged(QTreeWidgetItem* current, QTreeWidgetItem* pre
         fObjType->setText(item->obj()->ClassName());
         fLoadMaskQ[0]->setValue(item->obj()->getKey()->getLoadMask().getQuality(0));
         fLoadMaskQ[1]->setValue(item->obj()->getKey()->getLoadMask().getQuality(1));
+        fObjId->setText(QString("%1").arg(item->obj()->getKey()->getID()));
         fCloneId->setValue(item->obj()->getKey()->getCloneID());
         fClonePlayerId->setValue(item->obj()->getKey()->getClonePlayerID());
         fCloneIdBox->setChecked(fCloneId->value() != 0 || fClonePlayerId->value() != 0);

--- a/src/PrpShop/Main.h
+++ b/src/PrpShop/Main.h
@@ -57,6 +57,7 @@ private:
     QLineEdit* fObjName;
     QLabel* fObjType;
     QSpinBox* fLoadMaskQ[2];
+    QLabel* fObjId;
     QGroupBox* fCloneIdBox;
     QSpinBox* fCloneId;
     QSpinBox* fClonePlayerId;

--- a/src/PrpShop/Main.h
+++ b/src/PrpShop/Main.h
@@ -74,7 +74,7 @@ private:
     {
         // Main Menu
         kFileNewPage, kFileOpen, kFileSave, kFileSaveAs, kFileExit,
-        kToolsProperties, kToolsShowTypeIDs, kToolsNewObject, kWindowPrev,
+        kToolsProperties, kToolsShowTypeIDs, kToolsShowObjectIDs, kToolsNewObject, kWindowPrev,
         kWindowNext, kWindowTile, kWindowCascade, kWindowClose, kWindowCloseAll,
 
         // Tree Context Menu
@@ -121,6 +121,7 @@ public slots:
     void treeContextMenu(const QPoint& pos);
     void createNewObject();
     void showTypeIDs(bool show);
+    void showObjectIDs(bool show);
     void closeWindows(const plLocation& loc);
 
     void treeClose();

--- a/src/PrpShop/Main.h
+++ b/src/PrpShop/Main.h
@@ -74,8 +74,8 @@ private:
     {
         // Main Menu
         kFileNewPage, kFileOpen, kFileSave, kFileSaveAs, kFileExit,
-        kToolsProperties, kToolsShowTypeIDs, kToolsShowObjectIDs, kToolsNewObject, kWindowPrev,
-        kWindowNext, kWindowTile, kWindowCascade, kWindowClose, kWindowCloseAll,
+        kToolsProperties, kToolsShowAgePageIDs, kToolsShowTypeIDs, kToolsShowObjectIDs, kToolsNewObject,
+        kWindowPrev, kWindowNext, kWindowTile, kWindowCascade, kWindowClose, kWindowCloseAll,
 
         // Tree Context Menu
         kTreeClose, kTreeEdit, kTreeEditPRC, kTreeEditHex, kTreePreview,
@@ -120,6 +120,7 @@ public slots:
     void treeItemActivated(QTreeWidgetItem* item, int column);
     void treeContextMenu(const QPoint& pos);
     void createNewObject();
+    void showAgePageIDs(bool show);
     void showTypeIDs(bool show);
     void showObjectIDs(bool show);
     void closeWindows(const plLocation& loc);

--- a/src/PrpShop/PRP/Audio/QWinSound.cpp
+++ b/src/PrpShop/PRP/Audio/QWinSound.cpp
@@ -506,7 +506,7 @@ void QWinSound::editEaxSettings()
 {
     QEaxSourceSettings* eaxDlg = new QEaxSourceSettings(&(plSound::Convert(fCreatable))->getEAXSettings());
     eaxDlg->setWindowTitle(tr("EAX Settings: %1")
-                           .arg(st2qstr(plSound::Convert(fCreatable)->getKey()->getName())));
+                           .arg(pqFormatKeyName(plSound::Convert(fCreatable)->getKey())));
     eaxDlg->show();
 }
 

--- a/src/PrpShop/PRP/GUI/QGUIPopUpMenu.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIPopUpMenu.cpp
@@ -322,7 +322,7 @@ void QPopUpMenuItemDialog::init(pfGUIPopUpMenu::pfMenuItem* item, int idx)
     fItemIdx = idx;
     fName->setText(st2qstr(fItem->fName));
     fProcType->setCurrentIndex(fItem->fHandler == NULL ? 0 : fItem->fHandler->getType());
-    fSubMenuKey->setText(fItem->fSubMenu.Exists() ? st2qstr(fItem->fSubMenu->getName()) : tr("(Null)"));
+    fSubMenuKey->setText(fItem->fSubMenu.Exists() ? pqFormatKeyName(fItem->fSubMenu) : tr("(Null)"));
     fYOffsetToNext->setValue(fItem->fYOffsetToNext);
 }
 
@@ -365,7 +365,7 @@ void QPopUpMenuItemDialog::selectKey()
     dlg.init(PrpShopMain::ResManager(), fItem->fSubMenu);
     if (dlg.exec() == QDialog::Accepted) {
         fItem->fSubMenu = dlg.selection();
-        fSubMenuKey->setText(st2qstr(fItem->fSubMenu->getName()));
+        fSubMenuKey->setText(pqFormatKeyName(fItem->fSubMenu));
     } else {
         fItem->fSubMenu = plKey();
         fSubMenuKey->setText(tr("(Null)"));

--- a/src/PrpShop/PRP/GUI/QGUIRadioGroupCtrl.cpp
+++ b/src/PrpShop/PRP/GUI/QGUIRadioGroupCtrl.cpp
@@ -48,7 +48,7 @@ QGUIRadioGroupCtrl::QGUIRadioGroupCtrl(plCreatable* pCre, QWidget* parent)
     for (size_t i=0; i<ctrl->getControls().size(); i++) {
         fControls->addKey(ctrl->getControls()[i]);
         fDefaultValue->addItem(pqGetTypeIcon(ctrl->getControls()[i]->getType()),
-                               st2qstr(ctrl->getControls()[i]->getName()));
+                               pqFormatKeyName(ctrl->getControls()[i]));
     }
     fDefaultValue->setCurrentIndex(ctrl->getDefaultValue());
 
@@ -81,7 +81,7 @@ void QGUIRadioGroupCtrl::saveDamage()
 
 void QGUIRadioGroupCtrl::controlAdded(plKey ctrl)
 {
-    fDefaultValue->addItem(pqGetTypeIcon(ctrl->getType()), st2qstr(ctrl->getName()));
+    fDefaultValue->addItem(pqGetTypeIcon(ctrl->getType()), pqFormatKeyName(ctrl));
 }
 
 void QGUIRadioGroupCtrl::controlRemoved(int which)

--- a/src/PrpShop/PRP/Modifier/QPythonFileMod.cpp
+++ b/src/PrpShop/PRP/Modifier/QPythonFileMod.cpp
@@ -50,7 +50,7 @@ static QStringList makeParamItem(const plPythonParameter& param)
     else if (param.fValueType == plPythonParameter::kNone)
         row << "(None)";
     else if (param.fObjKey.Exists())
-        row << st2qstr(param.fObjKey->getName());
+        row << pqFormatKeyName(param.fObjKey);
     else
         row << "(None)";
     return row;
@@ -261,7 +261,7 @@ void QPythonParamDialog::init(const plPythonParameter& param)
     } else {
         fKey = param.fObjKey;
         if (fKey.Exists())
-            fKeyValue->setText(st2qstr(fKey->getName()));
+            fKeyValue->setText(pqFormatKeyName(fKey));
         else
             fKeyValue->setText("(None)");
     }
@@ -298,7 +298,7 @@ void QPythonParamDialog::selectKey()
     dlg.init(PrpShopMain::ResManager(), fKey);
     if (dlg.exec() == QDialog::Accepted) {
         fKey = dlg.selection();
-        fKeyValue->setText(st2qstr(fKey->getName()));
+        fKeyValue->setText(pqFormatKeyName(fKey));
     }
 }
 

--- a/src/PrpShop/PRP/Object/QDrawInterface.cpp
+++ b/src/PrpShop/PRP/Object/QDrawInterface.cpp
@@ -39,7 +39,7 @@ QDrawableList::QDrawableList(plKey container, QWidget* parent)
 void QDrawableList::addKey(plKey key, int dkey)
 {
     QTreeWidgetItem* item = new QTreeWidgetItem(this,
-        QStringList() << QString("%1").arg(dkey) << st2qstr(key->getName()));
+        QStringList() << QString("%1").arg(dkey) << pqFormatKeyName(key));
     item->setIcon(1, pqGetTypeIcon(key->getType()));
     fKeys << key;
     fDrawKeys << dkey;
@@ -114,7 +114,7 @@ void QFindDrawKeyDialog::init(plResManager* mgr, const plLocation& loc)
     fKeyBox->clear();
     fKeys = fResMgr->getKeys(fLocation, kDrawableSpans);
     for (size_t i=0; i<fKeys.size(); i++)
-        fKeyBox->addItem(st2qstr(fKeys[i]->getName()));
+        fKeyBox->addItem(pqFormatKeyName(fKeys[i]));
     fDrawKey->setValue(0);
 }
 

--- a/src/PrpShop/PRP/QCreatable.cpp
+++ b/src/PrpShop/PRP/QCreatable.cpp
@@ -30,7 +30,7 @@ QCreatable::QCreatable(plCreatable* pCre, int type, QWidget* parent)
     hsKeyedObject* ko = hsKeyedObject::Convert(fCreatable, false);
     if (ko != NULL && ko->getKey().Exists()) {
         setWindowTitle(pqGetFriendlyClassName(type) +
-                       ": " + st2qstr(ko->getKey()->getName()));
+                       ": " + pqFormatKeyName(ko->getKey()));
     } else {
         setWindowTitle(pqGetFriendlyClassName(type));
     }

--- a/src/PrpShop/PRP/QKeyList.cpp
+++ b/src/PrpShop/PRP/QKeyList.cpp
@@ -39,7 +39,7 @@ QKeyList::QKeyList(plKey container, QWidget* parent)
 void QKeyList::addKey(plKey key)
 {
     QTreeWidgetItem* item = new QTreeWidgetItem(this,
-        QStringList() << st2qstr(key->getName()) << pqGetFriendlyClassName(key->getType()));
+        QStringList() << pqFormatKeyName(key) << pqGetFriendlyClassName(key->getType()));
     item->setIcon(0, pqGetTypeIcon(key->getType()));
     fKeys << key;
 }

--- a/src/PrpShop/PRP/QObjLink.cpp
+++ b/src/PrpShop/PRP/QObjLink.cpp
@@ -57,7 +57,7 @@ void QCreatableLink::setKey(plKey key, bool updateText)
         fCreatable = key.isLoaded() ? key->getObj() : NULL;
         fObjLabel->setEnabled(true);
         if (updateText)
-            setText(st2qstr(key->getName()));
+            setText(pqFormatKeyName(key));
     } else {
         fCreatable = NULL;
         fObjLabel->setEnabled(false);

--- a/src/PrpShop/PRP/Render/QPlasmaRender.cpp
+++ b/src/PrpShop/PRP/Render/QPlasmaRender.cpp
@@ -422,7 +422,7 @@ bool QPlasmaRender::buildMipmap(plMipmap* map, GLuint id, GLuint target)
         } catch (hsException& e) {
             QMessageBox msgBox(QMessageBox::Critical, tr("Error"),
                                tr("Error decompressing %1: %2")
-                               .arg(st2qstr(map->getKey()->getName())).arg(e.what()),
+                               .arg(pqFormatKeyName(map->getKey())).arg(e.what()),
                                QMessageBox::Ok, this);
             msgBox.exec();
             delete[] imgbuf;

--- a/src/PrpShop/QKeyDialog.cpp
+++ b/src/PrpShop/QKeyDialog.cpp
@@ -194,5 +194,5 @@ void QFindKeyDialog::typeSelected(int idx)
 
     fKeys = fResMgr->getKeys(fLocations[fLocationBox->currentIndex()], fTypes[idx]);
     for (size_t i=0; i<fKeys.size(); i++)
-        fKeyBox->addItem(st2qstr(fKeys[i]->getName()));
+        fKeyBox->addItem(pqFormatKeyName(fKeys[i]));
 }

--- a/src/PrpShop/QPlasmaTreeItem.cpp
+++ b/src/PrpShop/QPlasmaTreeItem.cpp
@@ -26,7 +26,7 @@ QPlasmaTreeItem::QPlasmaTreeItem()
 QPlasmaTreeItem::QPlasmaTreeItem(plKey obj)
     : QTreeWidgetItem(kTypeKO), fObjKey(obj)
 {
-    setText(0, st2qstr(obj->getName()));
+    setText(0, pqFormatKeyName(obj));
     setIcon(0, pqGetTypeIcon(obj->getType()));
 }
 
@@ -54,7 +54,7 @@ QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent)
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, plKey obj)
     : QTreeWidgetItem(parent, kTypeKO), fObjKey(obj)
 {
-    setText(0, st2qstr(obj->getName()));
+    setText(0, pqFormatKeyName(obj));
     setIcon(0, pqGetTypeIcon(obj->getType()));
 }
 
@@ -82,7 +82,7 @@ QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent)
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, plKey obj)
     : QTreeWidgetItem(parent, kTypeKO), fObjKey(obj)
 {
-    setText(0, st2qstr(obj->getName()));
+    setText(0, pqFormatKeyName(obj));
     setIcon(0, pqGetTypeIcon(obj->getType()));
 }
 

--- a/src/PrpShop/QPlasmaTreeItem.cpp
+++ b/src/PrpShop/QPlasmaTreeItem.cpp
@@ -20,83 +20,98 @@
 QPlasmaTreeItem::QPlasmaTreeItem()
     : QTreeWidgetItem(kTypeNone)
 {
-    setIcon(0, QIcon(":/img/folder.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(plKey obj)
-    : QTreeWidgetItem(kTypeKO), fObjKey(obj)
+    : QTreeWidgetItem(kTypeKO), fObjKey(std::move(obj))
 {
-    setText(0, pqFormatKeyName(obj));
-    setIcon(0, pqGetTypeIcon(obj->getType()));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(const QString& age)
     : QTreeWidgetItem(kTypeAge), fHasBuiltIn(false), fHasTextures(false),
       fAge(age)
 {
-    setText(0, age);
-    setIcon(0, QIcon(":/img/age.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(plPageInfo* page)
     : QTreeWidgetItem(kTypePage), fPage(page)
 {
-    setText(0, st2qstr(page->getPage()));
-    setIcon(0, QIcon(":/img/page.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent)
     : QTreeWidgetItem(parent, kTypeNone)
 {
-    setIcon(0, QIcon(":/img/folder.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, plKey obj)
-    : QTreeWidgetItem(parent, kTypeKO), fObjKey(obj)
+    : QTreeWidgetItem(parent, kTypeKO), fObjKey(std::move(obj))
 {
-    setText(0, pqFormatKeyName(obj));
-    setIcon(0, pqGetTypeIcon(obj->getType()));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, const QString& age)
     : QTreeWidgetItem(parent, kTypeAge), fHasBuiltIn(false),
       fHasTextures(false), fAge(age)
 {
-    setText(0, age);
-    setIcon(0, QIcon(":/img/age.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, plPageInfo* page)
     : QTreeWidgetItem(parent, kTypePage), fPage(page)
 {
-    setText(0, st2qstr(page->getPage()));
-    setIcon(0, QIcon(":/img/page.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent)
     : QTreeWidgetItem(parent, kTypeNone)
 {
-    setIcon(0, QIcon(":/img/folder.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, plKey obj)
-    : QTreeWidgetItem(parent, kTypeKO), fObjKey(obj)
+    : QTreeWidgetItem(parent, kTypeKO), fObjKey(std::move(obj))
 {
-    setText(0, pqFormatKeyName(obj));
-    setIcon(0, pqGetTypeIcon(obj->getType()));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age)
     : QTreeWidgetItem(parent, kTypeAge), fHasBuiltIn(false),
       fHasTextures(false), fAge(age)
 {
-    setText(0, age);
-    setIcon(0, QIcon(":/img/age.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, plPageInfo* page)
     : QTreeWidgetItem(parent, kTypePage), fPage(page)
 {
-    setText(0, st2qstr(page->getPage()));
-    setIcon(0, QIcon(":/img/page.png"));
+    reinit();
+}
+
+void QPlasmaTreeItem::reinit()
+{
+    switch (type()) {
+        case kTypeNone:
+            setIcon(0, QIcon(":/img/folder.png"));
+            break;
+
+        case kTypeKO:
+            setText(0, pqFormatKeyName(fObjKey));
+            setIcon(0, pqGetTypeIcon(fObjKey->getType()));
+            break;
+
+        case kTypeAge:
+            setText(0, fAge);
+            setIcon(0, QIcon(":/img/age.png"));
+            break;
+
+        case kTypePage:
+            setText(0, st2qstr(fPage->getPage()));
+            setIcon(0, QIcon(":/img/page.png"));
+            break;
+    }
 }

--- a/src/PrpShop/QPlasmaTreeItem.cpp
+++ b/src/PrpShop/QPlasmaTreeItem.cpp
@@ -110,6 +110,18 @@ QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, plPageInfo* page)
     reinit();
 }
 
+static QString pqFormatPageName(const plPageInfo* page)
+{
+    if (s_showAgePageIDs) {
+        return QString("[%1;%2] %3")
+            .arg(page->getLocation().getSeqPrefix())
+            .arg(page->getLocation().getPageNum())
+            .arg(st2qstr(page->getPage()));
+    } else {
+        return st2qstr(page->getPage());
+    }
+}
+
 void QPlasmaTreeItem::reinit()
 {
     switch (type()) {
@@ -137,8 +149,8 @@ void QPlasmaTreeItem::reinit()
             break;
 
         case kTypePage:
-            fSortId = 0;
-            setText(0, st2qstr(fPage->getPage()));
+            fSortId = s_showAgePageIDs ? static_cast<int32_t>(fPage->getLocation().unparse()) : 0;
+            setText(0, pqFormatPageName(fPage));
             setIcon(0, QIcon(":/img/page.png"));
             break;
     }

--- a/src/PrpShop/QPlasmaTreeItem.cpp
+++ b/src/PrpShop/QPlasmaTreeItem.cpp
@@ -29,6 +29,12 @@ QPlasmaTreeItem::QPlasmaTreeItem(plKey obj)
     reinit();
 }
 
+QPlasmaTreeItem::QPlasmaTreeItem(short classType)
+    : QTreeWidgetItem(kTypeClassType), fClassType(classType)
+{
+    reinit();
+}
+
 QPlasmaTreeItem::QPlasmaTreeItem(const QString& age)
     : QTreeWidgetItem(kTypeAge), fHasBuiltIn(false), fHasTextures(false),
       fAge(age)
@@ -50,6 +56,12 @@ QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent)
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, plKey obj)
     : QTreeWidgetItem(parent, kTypeKO), fObjKey(std::move(obj))
+{
+    reinit();
+}
+
+QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, short classType)
+    : QTreeWidgetItem(parent, kTypeClassType), fClassType(classType)
 {
     reinit();
 }
@@ -79,6 +91,12 @@ QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, plKey obj)
     reinit();
 }
 
+QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, short classType)
+    : QTreeWidgetItem(parent, kTypeClassType), fClassType(classType)
+{
+    reinit();
+}
+
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age)
     : QTreeWidgetItem(parent, kTypeAge), fHasBuiltIn(false),
       fHasTextures(false), fAge(age)
@@ -102,6 +120,11 @@ void QPlasmaTreeItem::reinit()
         case kTypeKO:
             setText(0, pqFormatKeyName(fObjKey));
             setIcon(0, pqGetTypeIcon(fObjKey->getType()));
+            break;
+
+        case kTypeClassType:
+            setText(0, pqGetFriendlyClassName(fClassType));
+            setIcon(0, QIcon(":/img/folder.png"));
             break;
 
         case kTypeAge:

--- a/src/PrpShop/QPlasmaTreeItem.cpp
+++ b/src/PrpShop/QPlasmaTreeItem.cpp
@@ -114,27 +114,47 @@ void QPlasmaTreeItem::reinit()
 {
     switch (type()) {
         case kTypeNone:
+            fSortId = 0;
             setIcon(0, QIcon(":/img/folder.png"));
             break;
 
         case kTypeKO:
+            fSortId = s_showObjectIDs ? static_cast<int32_t>(fObjKey->getID()) : 0;
             setText(0, pqFormatKeyName(fObjKey));
             setIcon(0, pqGetTypeIcon(fObjKey->getType()));
             break;
 
         case kTypeClassType:
+            fSortId = s_showTypeIDs ? fClassType : 0;
             setText(0, pqGetFriendlyClassName(fClassType));
             setIcon(0, QIcon(":/img/folder.png"));
             break;
 
         case kTypeAge:
+            fSortId = 0;
             setText(0, fAge);
             setIcon(0, QIcon(":/img/age.png"));
             break;
 
         case kTypePage:
+            fSortId = 0;
             setText(0, st2qstr(fPage->getPage()));
             setIcon(0, QIcon(":/img/page.png"));
             break;
     }
+}
+
+bool QPlasmaTreeItem::operator<(const QTreeWidgetItem& other) const
+{
+    if (type() >= kTypeNone && type() < kMaxPlasmaTypes) {
+        // The other item is also one of ours,
+        // so try sorting numerically by ID.
+        auto otherPlasma = static_cast<const QPlasmaTreeItem&>(other);
+        if (fSortId != otherPlasma.fSortId) {
+            return fSortId < otherPlasma.fSortId;
+        }
+    }
+    // If the other item doesn't belong to us or if the two IDs are equal,
+    // fall back to default sorting by text.
+    return QTreeWidgetItem::operator<(other);
 }

--- a/src/PrpShop/QPlasmaTreeItem.h
+++ b/src/PrpShop/QPlasmaTreeItem.h
@@ -29,6 +29,7 @@ private:
     plPageInfo* fPage;
     bool fHasBuiltIn, fHasTextures;
     QString fAge;
+    int32_t fSortId;
 
     QString fFilename;
 
@@ -56,6 +57,8 @@ public:
     QPlasmaTreeItem(QTreeWidgetItem* parent, plPageInfo* page);
 
     void reinit();
+
+    bool operator<(const QTreeWidgetItem& other) const override;
 
     hsKeyedObject* obj() const { return (type() == kTypeKO) ? fObjKey->getObj() : NULL; }
     short classType() const { return (type() == kTypeClassType) ? fClassType : static_cast<short>(0x8000); }

--- a/src/PrpShop/QPlasmaTreeItem.h
+++ b/src/PrpShop/QPlasmaTreeItem.h
@@ -51,6 +51,8 @@ public:
     QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age);
     QPlasmaTreeItem(QTreeWidgetItem* parent, plPageInfo* page);
 
+    void reinit();
+
     hsKeyedObject* obj() const { return (type() == kTypeKO) ? fObjKey->getObj() : NULL; }
     QString age() const { return (type() == kTypeAge) ? fAge : QString(); }
     plPageInfo* page() const { return (type() == kTypePage) ? fPage : NULL; }

--- a/src/PrpShop/QPlasmaTreeItem.h
+++ b/src/PrpShop/QPlasmaTreeItem.h
@@ -25,6 +25,7 @@ class QPlasmaTreeItem : public QTreeWidgetItem
 {
 private:
     plKey fObjKey;
+    short fClassType;
     plPageInfo* fPage;
     bool fHasBuiltIn, fHasTextures;
     QString fAge;
@@ -34,26 +35,30 @@ private:
 public:
     enum ItemType
     {
-        kTypeNone = QTreeWidgetItem::UserType, kTypeAge, kTypePage, kTypeKO,
+        kTypeNone = QTreeWidgetItem::UserType, kTypeAge, kTypePage, kTypeClassType, kTypeKO,
         kMaxPlasmaTypes
     };
 
     QPlasmaTreeItem();
     QPlasmaTreeItem(plKey obj);
+    QPlasmaTreeItem(short classType);
     QPlasmaTreeItem(const QString& age);
     QPlasmaTreeItem(plPageInfo* page);
     QPlasmaTreeItem(QTreeWidget* parent);
     QPlasmaTreeItem(QTreeWidget* parent, plKey obj);
+    QPlasmaTreeItem(QTreeWidget* parent, short classType);
     QPlasmaTreeItem(QTreeWidget* parent, const QString& age);
     QPlasmaTreeItem(QTreeWidget* parent, plPageInfo* page);
     QPlasmaTreeItem(QTreeWidgetItem* parent);
     QPlasmaTreeItem(QTreeWidgetItem* parent, plKey obj);
+    QPlasmaTreeItem(QTreeWidgetItem* parent, short classType);
     QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age);
     QPlasmaTreeItem(QTreeWidgetItem* parent, plPageInfo* page);
 
     void reinit();
 
     hsKeyedObject* obj() const { return (type() == kTypeKO) ? fObjKey->getObj() : NULL; }
+    short classType() const { return (type() == kTypeClassType) ? fClassType : static_cast<short>(0x8000); }
     QString age() const { return (type() == kTypeAge) ? fAge : QString(); }
     plPageInfo* page() const { return (type() == kTypePage) ? fPage : NULL; }
 

--- a/src/PrpShop/QPlasmaUtils.cpp
+++ b/src/PrpShop/QPlasmaUtils.cpp
@@ -21,6 +21,7 @@
 #include <PRP/Object/plCoordinateInterface.h>
 #include <PRP/Object/plSceneObject.h>
 
+bool s_showAgePageIDs = false;
 bool s_showTypeIDs = false;
 bool s_showObjectIDs = false;
 

--- a/src/PrpShop/QPlasmaUtils.cpp
+++ b/src/PrpShop/QPlasmaUtils.cpp
@@ -588,7 +588,7 @@ QString pqFormatKeyName(const plKey& obj)
 {
     if (s_showObjectIDs) {
         return QString("[%1] %2")
-            .arg(obj->getID(), 8, 16, QChar('0'))
+            .arg(obj->getID())
             .arg(st2qstr(obj->getName()));
     } else {
         return st2qstr(obj->getName());

--- a/src/PrpShop/QPlasmaUtils.cpp
+++ b/src/PrpShop/QPlasmaUtils.cpp
@@ -22,6 +22,7 @@
 #include <PRP/Object/plSceneObject.h>
 
 bool s_showTypeIDs = false;
+bool s_showObjectIDs = false;
 
 enum
 {
@@ -581,6 +582,17 @@ QString pqGetFriendlyClassName(int classType)
             return s_names[classType];
     }
     return S_INVALID;
+}
+
+QString pqFormatKeyName(const plKey& obj)
+{
+    if (s_showObjectIDs) {
+        return QString("[%1] %2")
+            .arg(obj->getID(), 8, 16, QChar('0'))
+            .arg(st2qstr(obj->getName()));
+    } else {
+        return st2qstr(obj->getName());
+    }
 }
 
 std::vector<short> pqGetValidKOTypes()

--- a/src/PrpShop/QPlasmaUtils.h
+++ b/src/PrpShop/QPlasmaUtils.h
@@ -25,6 +25,7 @@
 #include "QPlasma.h"
 #include "QNumerics.h"
 
+extern bool s_showAgePageIDs;
 extern bool s_showTypeIDs;
 extern bool s_showObjectIDs;
 

--- a/src/PrpShop/QPlasmaUtils.h
+++ b/src/PrpShop/QPlasmaUtils.h
@@ -21,10 +21,12 @@
 #include <vector>
 #include <ResManager/pdUnifiedTypeMap.h>
 #include <PRP/plCreatable.h>
+#include <PRP/KeyedObject/plKey.h>
 #include "QPlasma.h"
 #include "QNumerics.h"
 
 extern bool s_showTypeIDs;
+extern bool s_showObjectIDs;
 
 enum
 {
@@ -44,6 +46,7 @@ enum
 
 QIcon pqGetTypeIcon(int);
 QString pqGetFriendlyClassName(int);
+QString pqFormatKeyName(const plKey& obj);
 
 std::vector<short> pqGetValidKOTypes();
 bool pqIsValidKOType(short);


### PR DESCRIPTION
We already have an option to display the type IDs next to the class names. This PR adds similar options for displaying the age/page IDs next to page names and object IDs next to object names. For example:

![Screenshot of Tools menu and Object Browser with age/page, type, and object IDs shown](https://github.com/H-uru/PlasmaShop/assets/6641959/2febc8d8-03ae-49ce-a086-15b95cf09d13)

This also refactors `QPlasmaTreeItem` a bit so that the items are properly sorted numerically by their ID (when shown). Previously, the sorting was lexicographic based on the displayed text, which doesn't work for variable-length numbers (e. g. 1, 2, 10 was sorted as 1 < 10 < 2).

One thing I'm not sure about: I remember something about libHSPlasma automatically changing object IDs in some cases. I don't know if the displayed object IDs might sometimes be inaccurate because of that...