### PR TITLE
Fix Layer SDL Animation base class editor

### DIFF
--- a/src/PrpShop/CMakeLists.txt
+++ b/src/PrpShop/CMakeLists.txt
@@ -56,6 +56,7 @@ set(PrpShop_Headers
     PRP/Surface/QFadeOpacityMod.h
     PRP/Surface/QLayer.h
     PRP/Surface/QLayerAnimation.h
+    PRP/Surface/QLayerAnimationBase.h
     PRP/Surface/QLayerLinkAnimation.h
     PRP/Surface/QLayerMovie.h
     PRP/Surface/QLayerSDLAnimation.h
@@ -126,6 +127,7 @@ set(PrpShop_Sources
     PRP/Surface/QFadeOpacityMod.cpp
     PRP/Surface/QLayer.cpp
     PRP/Surface/QLayerAnimation.cpp
+    PRP/Surface/QLayerAnimationBase.cpp
     PRP/Surface/QLayerLinkAnimation.cpp
     PRP/Surface/QLayerMovie.cpp
     PRP/Surface/QLayerSDLAnimation.cpp

--- a/src/PrpShop/PRP/QCreatable.cpp
+++ b/src/PrpShop/PRP/QCreatable.cpp
@@ -113,6 +113,7 @@ void QCreatable::closeEvent(QCloseEvent*)
 #include "PRP/Surface/QFadeOpacityMod.h"
 #include "PRP/Surface/QLayer.h"
 #include "PRP/Surface/QLayerAnimation.h"
+#include "PRP/Surface/QLayerAnimationBase.h"
 #include "PRP/Surface/QLayerLinkAnimation.h"
 #include "PRP/Surface/QLayerMovie.h"
 #include "PRP/Surface/QLayerSDLAnimation.h"
@@ -210,6 +211,8 @@ QCreatable* pqMakeCreatableForm(plCreatable* pCre, QWidget* parent, int forceTyp
         return new QLayer(pCre, parent);
     case kLayerAnimation:
         return new QLayerAnimation(pCre, parent);
+    case kLayerAnimationBase:
+        return new QLayerAnimationBase(pCre, parent);
     case kLayerAVI:
         return new QLayerMovie(pCre, parent);
     case kLayerBink:

--- a/src/PrpShop/PRP/Surface/QLayerAnimation.cpp
+++ b/src/PrpShop/PRP/Surface/QLayerAnimation.cpp
@@ -16,184 +16,23 @@
 
 #include "QLayerAnimation.h"
 
-#include <QLabel>
-#include <QGroupBox>
 #include <QGridLayout>
-#include <QSpacerItem>
-#include <ResManager/plFactory.h>
-#include "Main.h"
-#include "QKeyDialog.h"
+#include <PRP/Surface/plLayerAnimation.h>
 
 QLayerAnimation::QLayerAnimation(plCreatable* pCre, QWidget* parent)
     : QCreatable(pCre, kLayerAnimation, parent)
 {
     plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
 
-    fSynchObjLink = new QCreatableLink(this, false);
-    fSynchObjLink->setCreatable(lay, tr("Synch Flags"));
-    fSynchObjLink->setForceType(kSynchedObject);
-
-    fBaseLayer = new QCreatableLink(this);
-    fBaseLayer->setKey(lay->getUnderLay());
-
-    QGroupBox* controllerGroup = new QGroupBox(tr("Animation Controllers"), this);
-    QGridLayout* controllerLayout = new QGridLayout(controllerGroup);
-    controllerLayout->setVerticalSpacing(0);
-    controllerLayout->setHorizontalSpacing(8);
-    fPreshade = new QControllerLink(tr("Preshade Color"), controllerGroup);
-    fRuntime = new QControllerLink(tr("Runtime Color"), controllerGroup);
-    fAmbient = new QControllerLink(tr("Ambient Color"), controllerGroup);
-    fSpecular = new QControllerLink(tr("Specular Color"), controllerGroup);
-    fOpacity = new QControllerLink(tr("Opacity"), controllerGroup);
-    fTransform = new QControllerLink(tr("UVW Transform"), controllerGroup);
-    controllerLayout->addWidget(fPreshade, 0, 0);
-    controllerLayout->addWidget(fRuntime, 1, 0);
-    controllerLayout->addWidget(fAmbient, 2, 0);
-    controllerLayout->addWidget(fSpecular, 3, 0);
-    controllerLayout->addWidget(fOpacity, 4, 0);
-    controllerLayout->addWidget(fTransform, 5, 0);
-
-    fPreshade->setCreatable(lay->getPreshadeCtl());
-    fRuntime->setCreatable(lay->getRuntimeCtl());
-    fAmbient->setCreatable(lay->getAmbientCtl());
-    fSpecular->setCreatable(lay->getSpecularCtl());
-    fOpacity->setCreatable(lay->getOpacityCtl());
-    fTransform->setCreatable(lay->getTransformCtl());
+    fLayerAnimBaseLink = new QCreatableLink(this, false);
+    fLayerAnimBaseLink->setCreatable(lay, tr("Layer Animation Properties"));
+    fLayerAnimBaseLink->setForceType(kLayerAnimationBase);
 
     fAnimTimeConvert = new QCreatableLink(this, false);
     fAnimTimeConvert->setCreatable(&lay->getTimeConvert(), tr("Animation Time Properties"));
 
     QGridLayout* layout = new QGridLayout(this);
     layout->setContentsMargins(8, 8, 8, 8);
-    layout->addWidget(fSynchObjLink, 0, 0, 1, 2);
-    layout->addWidget(new QLabel(tr("Base Layer:"), this), 1, 0);
-    layout->addWidget(fBaseLayer, 1, 1);
-    layout->addWidget(controllerGroup, 2, 0, 1, 2);
-    layout->addWidget(fAnimTimeConvert, 3, 0, 1, 2);
-
-    connect(fBaseLayer, &QCreatableLink::addObject, this, &QLayerAnimation::setBaseLayer);
-    connect(fBaseLayer, &QCreatableLink::delObject, this, &QLayerAnimation::unsetBaseLayer);
-    connect(fPreshade, &QControllerLink::createObject, this, &QLayerAnimation::newPreshade);
-    connect(fPreshade, &QControllerLink::delObject, this, &QLayerAnimation::delPreshade);
-    connect(fRuntime, &QControllerLink::createObject, this, &QLayerAnimation::newRuntime);
-    connect(fRuntime, &QControllerLink::delObject, this, &QLayerAnimation::delRuntime);
-    connect(fAmbient, &QControllerLink::createObject, this, &QLayerAnimation::newAmbient);
-    connect(fAmbient, &QControllerLink::delObject, this, &QLayerAnimation::delAmbient);
-    connect(fSpecular, &QControllerLink::createObject, this, &QLayerAnimation::newSpecular);
-    connect(fSpecular, &QControllerLink::delObject, this, &QLayerAnimation::delSpecular);
-    connect(fOpacity, &QControllerLink::createObject, this, &QLayerAnimation::newOpacity);
-    connect(fOpacity, &QControllerLink::delObject, this, &QLayerAnimation::delOpacity);
-    connect(fTransform, &QControllerLink::createObject, this, &QLayerAnimation::newTransform);
-    connect(fTransform, &QControllerLink::delObject, this, &QLayerAnimation::delTransform);
-}
-
-void QLayerAnimation::setBaseLayer()
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    QFindKeyDialog dlg(this);
-    if (lay->getUnderLay().Exists())
-        dlg.init(PrpShopMain::ResManager(), lay->getUnderLay());
-    else
-        dlg.init(PrpShopMain::ResManager(), lay->getKey()->getLocation(), kLayer);
-    if (dlg.exec() == QDialog::Accepted) {
-        lay->setUnderLay(dlg.selection());
-        fBaseLayer->setKey(lay->getUnderLay());
-    }
-}
-
-void QLayerAnimation::unsetBaseLayer()
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    lay->setUnderLay(plKey());
-    fBaseLayer->setCreatable(NULL, "(None)");
-}
-
-void QLayerAnimation::newPreshade(short type)
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    plController* pCre = plController::Convert(plFactory::Create(type));
-    lay->setPreshadeCtl(pCre);
-    fPreshade->setCreatable(pCre);
-}
-
-void QLayerAnimation::newRuntime(short type)
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    plController* pCre = plController::Convert(plFactory::Create(type));
-    lay->setRuntimeCtl(pCre);
-    fRuntime->setCreatable(pCre);
-}
-
-void QLayerAnimation::newAmbient(short type)
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    plController* pCre = plController::Convert(plFactory::Create(type));
-    lay->setAmbientCtl(pCre);
-    fAmbient->setCreatable(pCre);
-}
-
-void QLayerAnimation::newSpecular(short type)
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    plController* pCre = plController::Convert(plFactory::Create(type));
-    lay->setSpecularCtl(pCre);
-    fSpecular->setCreatable(pCre);
-}
-
-void QLayerAnimation::newOpacity(short type)
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    plController* pCre = plController::Convert(plFactory::Create(type));
-    lay->setOpacityCtl(pCre);
-    fOpacity->setCreatable(pCre);
-}
-
-void QLayerAnimation::newTransform(short type)
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    plController* pCre = plController::Convert(plFactory::Create(type));
-    lay->setTransformCtl(pCre);
-    fTransform->setCreatable(pCre);
-}
-
-void QLayerAnimation::delPreshade()
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    lay->setPreshadeCtl(NULL);
-    fPreshade->setCreatable(NULL);
-}
-
-void QLayerAnimation::delRuntime()
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    lay->setRuntimeCtl(NULL);
-    fRuntime->setCreatable(NULL);
-}
-
-void QLayerAnimation::delAmbient()
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    lay->setAmbientCtl(NULL);
-    fAmbient->setCreatable(NULL);
-}
-
-void QLayerAnimation::delSpecular()
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    lay->setSpecularCtl(NULL);
-    fSpecular->setCreatable(NULL);
-}
-
-void QLayerAnimation::delOpacity()
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    lay->setOpacityCtl(NULL);
-    fOpacity->setCreatable(NULL);
-}
-
-void QLayerAnimation::delTransform()
-{
-    plLayerAnimation* lay = plLayerAnimation::Convert(fCreatable);
-    lay->setTransformCtl(NULL);
-    fTransform->setCreatable(NULL);
+    layout->addWidget(fLayerAnimBaseLink, 0, 0);
+    layout->addWidget(fAnimTimeConvert, 1, 0);
 }

--- a/src/PrpShop/PRP/Surface/QLayerAnimation.h
+++ b/src/PrpShop/PRP/Surface/QLayerAnimation.h
@@ -19,45 +19,18 @@
 
 #include "PRP/QCreatable.h"
 
-#include <PRP/Surface/plLayerAnimation.h>
 #include "PRP/QObjLink.h"
-#include "PRP/QMatrix44.h"
-#include "QColorEdit.h"
 
 class QLayerAnimation : public QCreatable
 {
     Q_OBJECT
 
 protected:
-    QCreatableLink* fSynchObjLink;
-    QCreatableLink* fBaseLayer;
-    QControllerLink* fPreshade;
-    QControllerLink* fRuntime;
-    QControllerLink* fAmbient;
-    QControllerLink* fSpecular;
-    QControllerLink* fOpacity;
-    QControllerLink* fTransform;
+    QCreatableLink* fLayerAnimBaseLink;
     QCreatableLink* fAnimTimeConvert;
 
 public:
     QLayerAnimation(plCreatable* pCre, QWidget* parent = NULL);
-
-protected slots:
-    void setBaseLayer();
-    void unsetBaseLayer();
-
-    void newPreshade(short type);
-    void newRuntime(short type);
-    void newAmbient(short type);
-    void newSpecular(short type);
-    void newOpacity(short type);
-    void newTransform(short type);
-    void delPreshade();
-    void delRuntime();
-    void delAmbient();
-    void delSpecular();
-    void delOpacity();
-    void delTransform();
 };
 
 #endif

--- a/src/PrpShop/PRP/Surface/QLayerAnimationBase.cpp
+++ b/src/PrpShop/PRP/Surface/QLayerAnimationBase.cpp
@@ -1,0 +1,195 @@
+/* This file is part of PlasmaShop.
+ *
+ * PlasmaShop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlasmaShop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PlasmaShop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "QLayerAnimationBase.h"
+
+#include <PRP/Surface/plLayerAnimation.h>
+#include <QLabel>
+#include <QGroupBox>
+#include <QGridLayout>
+#include <ResManager/plFactory.h>
+#include "Main.h"
+#include "QKeyDialog.h"
+
+QLayerAnimationBase::QLayerAnimationBase(plCreatable* pCre, QWidget* parent)
+    : QCreatable(pCre, kLayerAnimationBase, parent)
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+
+    fSynchObjLink = new QCreatableLink(this, false);
+    fSynchObjLink->setCreatable(lay, tr("Synch Flags"));
+    fSynchObjLink->setForceType(kSynchedObject);
+
+    fBaseLayer = new QCreatableLink(this);
+    fBaseLayer->setKey(lay->getUnderLay());
+
+    QGroupBox* controllerGroup = new QGroupBox(tr("Animation Controllers"), this);
+    QGridLayout* controllerLayout = new QGridLayout(controllerGroup);
+    controllerLayout->setVerticalSpacing(0);
+    controllerLayout->setHorizontalSpacing(8);
+    fPreshade = new QControllerLink(tr("Preshade Color"), controllerGroup);
+    fRuntime = new QControllerLink(tr("Runtime Color"), controllerGroup);
+    fAmbient = new QControllerLink(tr("Ambient Color"), controllerGroup);
+    fSpecular = new QControllerLink(tr("Specular Color"), controllerGroup);
+    fOpacity = new QControllerLink(tr("Opacity"), controllerGroup);
+    fTransform = new QControllerLink(tr("UVW Transform"), controllerGroup);
+    controllerLayout->addWidget(fPreshade, 0, 0);
+    controllerLayout->addWidget(fRuntime, 1, 0);
+    controllerLayout->addWidget(fAmbient, 2, 0);
+    controllerLayout->addWidget(fSpecular, 3, 0);
+    controllerLayout->addWidget(fOpacity, 4, 0);
+    controllerLayout->addWidget(fTransform, 5, 0);
+
+    fPreshade->setCreatable(lay->getPreshadeCtl());
+    fRuntime->setCreatable(lay->getRuntimeCtl());
+    fAmbient->setCreatable(lay->getAmbientCtl());
+    fSpecular->setCreatable(lay->getSpecularCtl());
+    fOpacity->setCreatable(lay->getOpacityCtl());
+    fTransform->setCreatable(lay->getTransformCtl());
+
+    QGridLayout* layout = new QGridLayout(this);
+    layout->setContentsMargins(8, 8, 8, 8);
+    layout->addWidget(fSynchObjLink, 0, 0, 1, 2);
+    layout->addWidget(new QLabel(tr("Base Layer:"), this), 1, 0);
+    layout->addWidget(fBaseLayer, 1, 1);
+    layout->addWidget(controllerGroup, 2, 0, 1, 2);
+
+    connect(fBaseLayer, &QCreatableLink::addObject, this, &QLayerAnimationBase::setBaseLayer);
+    connect(fBaseLayer, &QCreatableLink::delObject, this, &QLayerAnimationBase::unsetBaseLayer);
+    connect(fPreshade, &QControllerLink::createObject, this, &QLayerAnimationBase::newPreshade);
+    connect(fPreshade, &QControllerLink::delObject, this, &QLayerAnimationBase::delPreshade);
+    connect(fRuntime, &QControllerLink::createObject, this, &QLayerAnimationBase::newRuntime);
+    connect(fRuntime, &QControllerLink::delObject, this, &QLayerAnimationBase::delRuntime);
+    connect(fAmbient, &QControllerLink::createObject, this, &QLayerAnimationBase::newAmbient);
+    connect(fAmbient, &QControllerLink::delObject, this, &QLayerAnimationBase::delAmbient);
+    connect(fSpecular, &QControllerLink::createObject, this, &QLayerAnimationBase::newSpecular);
+    connect(fSpecular, &QControllerLink::delObject, this, &QLayerAnimationBase::delSpecular);
+    connect(fOpacity, &QControllerLink::createObject, this, &QLayerAnimationBase::newOpacity);
+    connect(fOpacity, &QControllerLink::delObject, this, &QLayerAnimationBase::delOpacity);
+    connect(fTransform, &QControllerLink::createObject, this, &QLayerAnimationBase::newTransform);
+    connect(fTransform, &QControllerLink::delObject, this, &QLayerAnimationBase::delTransform);
+}
+
+void QLayerAnimationBase::setBaseLayer()
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    QFindKeyDialog dlg(this);
+    if (lay->getUnderLay().Exists())
+        dlg.init(PrpShopMain::ResManager(), lay->getUnderLay());
+    else
+        dlg.init(PrpShopMain::ResManager(), lay->getKey()->getLocation(), kLayer);
+    if (dlg.exec() == QDialog::Accepted) {
+        lay->setUnderLay(dlg.selection());
+        fBaseLayer->setKey(lay->getUnderLay());
+    }
+}
+
+void QLayerAnimationBase::unsetBaseLayer()
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    lay->setUnderLay(plKey());
+    fBaseLayer->setCreatable(nullptr, "(None)");
+}
+
+void QLayerAnimationBase::newPreshade(short type)
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    plController* pCre = plController::Convert(plFactory::Create(type));
+    lay->setPreshadeCtl(pCre);
+    fPreshade->setCreatable(pCre);
+}
+
+void QLayerAnimationBase::newRuntime(short type)
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    plController* pCre = plController::Convert(plFactory::Create(type));
+    lay->setRuntimeCtl(pCre);
+    fRuntime->setCreatable(pCre);
+}
+
+void QLayerAnimationBase::newAmbient(short type)
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    plController* pCre = plController::Convert(plFactory::Create(type));
+    lay->setAmbientCtl(pCre);
+    fAmbient->setCreatable(pCre);
+}
+
+void QLayerAnimationBase::newSpecular(short type)
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    plController* pCre = plController::Convert(plFactory::Create(type));
+    lay->setSpecularCtl(pCre);
+    fSpecular->setCreatable(pCre);
+}
+
+void QLayerAnimationBase::newOpacity(short type)
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    plController* pCre = plController::Convert(plFactory::Create(type));
+    lay->setOpacityCtl(pCre);
+    fOpacity->setCreatable(pCre);
+}
+
+void QLayerAnimationBase::newTransform(short type)
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    plController* pCre = plController::Convert(plFactory::Create(type));
+    lay->setTransformCtl(pCre);
+    fTransform->setCreatable(pCre);
+}
+
+void QLayerAnimationBase::delPreshade()
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    lay->setPreshadeCtl(nullptr);
+    fPreshade->setCreatable(nullptr);
+}
+
+void QLayerAnimationBase::delRuntime()
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    lay->setRuntimeCtl(nullptr);
+    fRuntime->setCreatable(nullptr);
+}
+
+void QLayerAnimationBase::delAmbient()
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    lay->setAmbientCtl(nullptr);
+    fAmbient->setCreatable(nullptr);
+}
+
+void QLayerAnimationBase::delSpecular()
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    lay->setSpecularCtl(nullptr);
+    fSpecular->setCreatable(nullptr);
+}
+
+void QLayerAnimationBase::delOpacity()
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    lay->setOpacityCtl(nullptr);
+    fOpacity->setCreatable(nullptr);
+}
+
+void QLayerAnimationBase::delTransform()
+{
+    plLayerAnimationBase* lay = plLayerAnimationBase::Convert(fCreatable);
+    lay->setTransformCtl(nullptr);
+    fTransform->setCreatable(nullptr);
+}

--- a/src/PrpShop/PRP/Surface/QLayerAnimationBase.h
+++ b/src/PrpShop/PRP/Surface/QLayerAnimationBase.h
@@ -1,0 +1,59 @@
+/* This file is part of PlasmaShop.
+ *
+ * PlasmaShop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PlasmaShop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PlasmaShop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _QLAYERANIMATIONBASE_H
+#define _QLAYERANIMATIONBASE_H
+
+#include "PRP/QCreatable.h"
+
+#include "PRP/QObjLink.h"
+
+class QLayerAnimationBase : public QCreatable
+{
+    Q_OBJECT
+
+protected:
+    QCreatableLink* fSynchObjLink;
+    QCreatableLink* fBaseLayer;
+    QControllerLink* fPreshade;
+    QControllerLink* fRuntime;
+    QControllerLink* fAmbient;
+    QControllerLink* fSpecular;
+    QControllerLink* fOpacity;
+    QControllerLink* fTransform;
+
+public:
+    QLayerAnimationBase(plCreatable* pCre, QWidget* parent = nullptr);
+
+protected slots:
+    void setBaseLayer();
+    void unsetBaseLayer();
+
+    void newPreshade(short type);
+    void newRuntime(short type);
+    void newAmbient(short type);
+    void newSpecular(short type);
+    void newOpacity(short type);
+    void newTransform(short type);
+    void delPreshade();
+    void delRuntime();
+    void delAmbient();
+    void delSpecular();
+    void delOpacity();
+    void delTransform();
+};
+
+#endif

--- a/src/PrpShop/PRP/Surface/QLayerSDLAnimation.cpp
+++ b/src/PrpShop/PRP/Surface/QLayerSDLAnimation.cpp
@@ -27,7 +27,7 @@ QLayerSDLAnimation::QLayerSDLAnimation(plCreatable* pCre, QWidget* parent)
 
     fLayerAnimLink = new QCreatableLink(this, false);
     fLayerAnimLink->setCreatable(lay, tr("Layer Animation Properties"));
-    fLayerAnimLink->setForceType(kLayerAnimation);
+    fLayerAnimLink->setForceType(kLayerAnimationBase);
 
     fVarName = new QLineEdit(this);
     fVarName->setText(st2qstr(lay->getVarName()));

--- a/src/PrpShop/QPlasmaUtils.cpp
+++ b/src/PrpShop/QPlasmaUtils.cpp
@@ -79,6 +79,8 @@ QIcon pqGetTypeIcon(int classType)
         return s_icons[kIcoLayer];
     case kLayerAnimation:
         return s_icons[kIcoLayer];
+    case kLayerAnimationBase:
+        return s_icons[kIcoLayer];
     case kLayerDepth:
         return s_icons[kIcoLayer];
     case kLayerSDLAnimation:
@@ -595,7 +597,7 @@ std::vector<short> pqGetValidKOTypes()
         kGUIEditBoxMod, kGUIKnobCtrl, kGUIListBoxMod, kGUIMenuItem,
         kGUIMultiLineEditCtrl, kGUIPopUpMenu, kGUIProgressCtrl,
         kGUIRadioGroupCtrl, kGUISkin, kGUITextBoxMod, kGUIUpDownPairMod,
-        kImageLibMod, kInterfaceInfoModifier, kLayer, kLayerAnimation,
+        kImageLibMod, kInterfaceInfoModifier, kLayer, kLayerAnimation, kLayerAnimationBase,
         kLayerAVI, kLayerBink, kLayerDepth, kLayerLinkAnimation, kLayerMovie,
         kLayerSDLAnimation, kGMaterial, kMaintainersMarkerModifier, kMipmap,
         kMsgForwarder, kMultistageBehMod, kOneShotMod, kPanicLinkRegion,


### PR DESCRIPTION
Related to (but technically not dependent on) H-uru/libhsplasma#281. This does two things:

* Fixes the "Layer Animation Properties" link in `QLayerSDLAnimation` to cast to the correct base class (`plLayerAnimationBase`). Previously, clicking the link crashed PrpShop.
* Adds a `QLayerAnimationBase` editor to support the link with the corrected class. This editor is split out of `QLayerAnimation`, and I've made that link to the new editor as well, instead of having the base class editor "inline". (This matches how PrpShop handles other base class chains like this, e. g. the Win32 sounds.)

Before:

![Screenshot before: Layer Animation is one dialog](https://github.com/H-uru/PlasmaShop/assets/6641959/8981a0f7-f109-4bc0-9ebf-26941bb953cf)

After:

![Screenshot after: Layer Animation is split into two dialogs, and Layer SDL Animation has a working base link](https://github.com/H-uru/PlasmaShop/assets/6641959/8a0f703f-3314-42c7-bd96-5264dfd2b7cb)