### PR TITLE
Display mipmap preview levels as tabs instead of using a spinner

### DIFF
--- a/src/PrpShop/PRP/Surface/QMipmap.h
+++ b/src/PrpShop/PRP/Surface/QMipmap.h
@@ -21,7 +21,6 @@
 
 #include <PRP/Surface/plMipmap.h>
 #include <QImage>
-#include <QSpinBox>
 #include "PRP/QObjLink.h"
 #include "QBitmaskCheckBox.h"
 


### PR DESCRIPTION
This improves a part of the mipmap preview window that I found confusing at first - the "Level" spinner at the top:

![Screenshot of mipmap preview window so far, with a spinner for selecting the level](https://github.com/H-uru/PlasmaShop/assets/6641959/6f7e328f-09cd-4e96-bd08-f9b96cc603bf)

When I first used this preview window, I assumed that the level was a property stored in the mipmap object. I expected that changing the spinner would modify the PRP file, so I never touched it. I didn't realize that the spinner has no permanent effect and actually lets you preview other mipmap levels beyond the first one.

This PR replaces the spinner with a tab bar, which IMO communicates the meaning and behavior more clearly. As a bonus, the tab titles also display each level's pixel width/height.

![Screenshot of new mipmap preview window, with tabs for selecting the level](https://github.com/H-uru/PlasmaShop/assets/6641959/ebc31f21-8fc1-49c2-9a25-963772eff99d)