### PR TITLE
Allow displaying age/page IDs in Object Browser tree

### DIFF
--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -1017,6 +1017,7 @@ void PrpShopMain::saveFile(plPageInfo* page, QString filename)
 void PrpShopMain::saveProps(QPlasmaTreeItem* item)
 {
     if (item != NULL) {
+        bool reinit = false;
         bool refreshTree = false;
         if (item->type() == QPlasmaTreeItem::kTypePage) {
             if (fAgeName->text() != st2qstr(item->page()->getAge())) {
@@ -1029,7 +1030,7 @@ void PrpShopMain::saveProps(QPlasmaTreeItem* item)
             }
             if (fPageName->text() != st2qstr(item->page()->getPage())) {
                 item->page()->setPage(qstr2st(fPageName->text()));
-                item->setText(0, fPageName->text());
+                reinit = true;
                 refreshTree = true;
             }
             if (fReleaseVersion->value() != (int)item->page()->getReleaseVersion())
@@ -1046,12 +1047,13 @@ void PrpShopMain::saveProps(QPlasmaTreeItem* item)
                 fLoadedLocations[loc] = fLoadedLocations[item->page()->getLocation()];
                 fLoadedLocations.erase(fLoadedLocations.find(item->page()->getLocation()));
                 fResMgr.ChangeLocation(item->page()->getLocation(), loc);
+                reinit = true;
             }
         } else if (item->type() == QPlasmaTreeItem::kTypeKO) {
             if (item->obj() != NULL) {
                 if (fObjName->text() != st2qstr(item->obj()->getKey()->getName())) {
                     item->obj()->getKey()->setName(qstr2st(fObjName->text()));
-                    item->setText(0, fObjName->text());
+                    reinit = true;
                     refreshTree = true;
                 }
                 plLoadMask mask = item->obj()->getKey()->getLoadMask();
@@ -1060,6 +1062,10 @@ void PrpShopMain::saveProps(QPlasmaTreeItem* item)
                 if (fCloneIdBox->isChecked())
                     item->obj()->getKey()->setCloneIDs(fCloneId->value(), fClonePlayerId->value());
             }
+        }
+        if (reinit) {
+            item->reinit();
+            item->parent()->sortChildren(0, Qt::AscendingOrder);
         }
         if (refreshTree)
             fBrowserTree->sortItems(0, Qt::AscendingOrder);

--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -569,10 +569,10 @@ QPlasmaTreeItem* PrpShopMain::ensurePath(const plLocation& loc, short objType)
     plPageInfo* page = fResMgr.FindPage(loc);
     QPlasmaTreeItem* ageItem = NULL;
     QString ageName = st2qstr(page->getAge());
-    QString pageName = st2qstr(page->getPage());
     for (int i=0; i<fBrowserTree->topLevelItemCount(); i++) {
-        if (fBrowserTree->topLevelItem(i)->text(0) == ageName) {
-            ageItem = (QPlasmaTreeItem*)fBrowserTree->topLevelItem(i);
+        auto topLevelItem = static_cast<QPlasmaTreeItem*>(fBrowserTree->topLevelItem(i));
+        if (topLevelItem->age() == ageName) {
+            ageItem = topLevelItem;
             break;
         }
     }
@@ -581,8 +581,9 @@ QPlasmaTreeItem* PrpShopMain::ensurePath(const plLocation& loc, short objType)
 
     QPlasmaTreeItem* pageItem = NULL;
     for (int i=0; i<ageItem->childCount(); i++) {
-        if (ageItem->child(i)->text(0) == pageName) {
-            pageItem = (QPlasmaTreeItem*)ageItem->child(i);
+        auto child = static_cast<QPlasmaTreeItem*>(ageItem->child(i));
+        if (child->page()->getLocation() == loc) {
+            pageItem = child;
             break;
         }
     }
@@ -1076,8 +1077,9 @@ QPlasmaTreeItem* PrpShopMain::loadPage(plPageInfo* page, QString filename)
         // Find or create the Age folder
         QString ageName = st2qstr(page->getAge());
         for (int i=0; i<fBrowserTree->topLevelItemCount(); i++) {
-            if (fBrowserTree->topLevelItem(i)->text(0) == ageName) {
-                parent = (QPlasmaTreeItem*)fBrowserTree->topLevelItem(i);
+            auto topLevelItem = static_cast<QPlasmaTreeItem*>(fBrowserTree->topLevelItem(i));
+            if (topLevelItem->age() == ageName) {
+                parent = topLevelItem;
                 break;
             }
         }

--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -1084,7 +1084,7 @@ QPlasmaTreeItem* PrpShopMain::loadPage(plPageInfo* page, QString filename)
             }
         }
         if (parent == NULL)
-            parent = new QPlasmaTreeItem(fBrowserTree, ageName);
+            parent = new QPlasmaTreeItem(fBrowserTree, ageName, page->getLocation().getSeqPrefix());
 
         // Treat BuiltIn and Textures PRPs specially:
         if (page->getLocation().getPageNum() == -1)
@@ -1174,7 +1174,7 @@ void PrpShopMain::showAgePageIDs(bool show)
 {
     s_showAgePageIDs = show;
 
-    // Refresh currently loaded pages
+    // Refresh currently loaded ages/pages
     for (int i=0; i<fBrowserTree->topLevelItemCount(); i++) {
         QPlasmaTreeItem* ageNode = (QPlasmaTreeItem*)fBrowserTree->topLevelItem(i);
         for (int j=0; j<ageNode->childCount(); j++) {
@@ -1182,7 +1182,9 @@ void PrpShopMain::showAgePageIDs(bool show)
             pageNode->reinit();
         }
         ageNode->sortChildren(0, Qt::AscendingOrder);
+        ageNode->reinit();
     }
+    fBrowserTree->sortItems(0, Qt::AscendingOrder);
 }
 
 void PrpShopMain::showTypeIDs(bool show)

--- a/src/PrpShop/Main.h
+++ b/src/PrpShop/Main.h
@@ -73,8 +73,8 @@ private:
     {
         // Main Menu
         kFileNewPage, kFileOpen, kFileSave, kFileSaveAs, kFileExit,
-        kToolsProperties, kToolsShowTypeIDs, kToolsNewObject, kWindowPrev,
-        kWindowNext, kWindowTile, kWindowCascade, kWindowClose, kWindowCloseAll,
+        kToolsProperties, kToolsShowAgePageIDs, kToolsShowTypeIDs, kToolsNewObject,
+        kWindowPrev, kWindowNext, kWindowTile, kWindowCascade, kWindowClose, kWindowCloseAll,
 
         // Tree Context Menu
         kTreeClose, kTreeEdit, kTreeEditPRC, kTreeEditHex, kTreePreview,
@@ -119,6 +119,7 @@ public slots:
     void treeItemActivated(QTreeWidgetItem* item, int column);
     void treeContextMenu(const QPoint& pos);
     void createNewObject();
+    void showAgePageIDs(bool show);
     void showTypeIDs(bool show);
     void closeWindows(const plLocation& loc);
 

--- a/src/PrpShop/QPlasmaTreeItem.cpp
+++ b/src/PrpShop/QPlasmaTreeItem.cpp
@@ -37,9 +37,9 @@ QPlasmaTreeItem::QPlasmaTreeItem(short classType)
     reinit();
 }
 
-QPlasmaTreeItem::QPlasmaTreeItem(const QString& age)
+QPlasmaTreeItem::QPlasmaTreeItem(const QString& age, int ageSeqPrefix)
     : QTreeWidgetItem(kTypeAge), fHasBuiltIn(false), fHasTextures(false),
-      fAge(age)
+      fAge(age), fAgeSeqPrefix(ageSeqPrefix)
 {
     reinit();
 }
@@ -68,9 +68,9 @@ QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, short classType)
     reinit();
 }
 
-QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, const QString& age)
+QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, const QString& age, int ageSeqPrefix)
     : QTreeWidgetItem(parent, kTypeAge), fHasBuiltIn(false),
-      fHasTextures(false), fAge(age)
+      fHasTextures(false), fAge(age), fAgeSeqPrefix(ageSeqPrefix)
 {
     reinit();
 }
@@ -99,9 +99,9 @@ QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, short classType)
     reinit();
 }
 
-QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age)
+QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age, int ageSeqPrefix)
     : QTreeWidgetItem(parent, kTypeAge), fHasBuiltIn(false),
-      fHasTextures(false), fAge(age)
+      fHasTextures(false), fAge(age), fAgeSeqPrefix(ageSeqPrefix)
 {
     reinit();
 }
@@ -118,6 +118,15 @@ static QString pqFormatPageName(const plPageInfo* page)
         return st2qstr(ST::format("{} {}", page->getLocation().toString(), page->getPage()));
     } else {
         return st2qstr(page->getPage());
+    }
+}
+
+static QString pqFormatAgeName(const QString& name, int seqPrefix)
+{
+    if (s_showAgePageIDs) {
+        return QString("<%1> %2").arg(seqPrefix).arg(name);
+    } else {
+        return name;
     }
 }
 
@@ -139,7 +148,7 @@ void QPlasmaTreeItem::reinit()
             break;
 
         case kTypeAge:
-            setText(0, fAge);
+            setText(0, pqFormatAgeName(fAge, fAgeSeqPrefix));
             setIcon(0, QIcon(":/img/age.png"));
             break;
 
@@ -163,6 +172,11 @@ bool QPlasmaTreeItem::operator<(const QTreeWidgetItem& other) const
         // (i. e. first by age ID, then by page ID).
         auto otherPlasma = static_cast<const QPlasmaTreeItem&>(other);
         return fPage->getLocation() < otherPlasma.fPage->getLocation();
+    } else if (s_showAgePageIDs && type() == kTypeAge && other.type() == kTypeAge) {
+        // If age/page IDs are shown,
+        // sort ages by their ID (sequence prefix).
+        auto otherPlasma = static_cast<const QPlasmaTreeItem&>(other);
+        return fAgeSeqPrefix < otherPlasma.fAgeSeqPrefix;
     } else if (type() != other.type()) {
         // Sort items of different types by their type,
         // i. e. group items of the same type together.

--- a/src/PrpShop/QPlasmaTreeItem.cpp
+++ b/src/PrpShop/QPlasmaTreeItem.cpp
@@ -29,6 +29,12 @@ QPlasmaTreeItem::QPlasmaTreeItem(plKey obj)
     reinit();
 }
 
+QPlasmaTreeItem::QPlasmaTreeItem(short classType)
+    : QTreeWidgetItem(kTypeClassType), fClassType(classType)
+{
+    reinit();
+}
+
 QPlasmaTreeItem::QPlasmaTreeItem(const QString& age)
     : QTreeWidgetItem(kTypeAge), fHasBuiltIn(false), fHasTextures(false),
       fAge(age)
@@ -50,6 +56,12 @@ QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent)
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, plKey obj)
     : QTreeWidgetItem(parent, kTypeKO), fObjKey(std::move(obj))
+{
+    reinit();
+}
+
+QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, short classType)
+    : QTreeWidgetItem(parent, kTypeClassType), fClassType(classType)
 {
     reinit();
 }
@@ -79,6 +91,12 @@ QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, plKey obj)
     reinit();
 }
 
+QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, short classType)
+    : QTreeWidgetItem(parent, kTypeClassType), fClassType(classType)
+{
+    reinit();
+}
+
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age)
     : QTreeWidgetItem(parent, kTypeAge), fHasBuiltIn(false),
       fHasTextures(false), fAge(age)
@@ -102,6 +120,11 @@ void QPlasmaTreeItem::reinit()
         case kTypeKO:
             setText(0, st2qstr(fObjKey->getName()));
             setIcon(0, pqGetTypeIcon(fObjKey->getType()));
+            break;
+
+        case kTypeClassType:
+            setText(0, pqGetFriendlyClassName(fClassType));
+            setIcon(0, QIcon(":/img/folder.png"));
             break;
 
         case kTypeAge:

--- a/src/PrpShop/QPlasmaTreeItem.cpp
+++ b/src/PrpShop/QPlasmaTreeItem.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "QPlasmaTreeItem.h"
+
+#include <string_theory/format>
 #include "QPlasmaUtils.h"
 
 QPlasmaTreeItem::QPlasmaTreeItem()
@@ -110,6 +112,15 @@ QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, plPageInfo* page)
     reinit();
 }
 
+static QString pqFormatPageName(const plPageInfo* page)
+{
+    if (s_showAgePageIDs) {
+        return st2qstr(ST::format("{} {}", page->getLocation().toString(), page->getPage()));
+    } else {
+        return st2qstr(page->getPage());
+    }
+}
+
 void QPlasmaTreeItem::reinit()
 {
     switch (type()) {
@@ -133,7 +144,7 @@ void QPlasmaTreeItem::reinit()
             break;
 
         case kTypePage:
-            setText(0, st2qstr(fPage->getPage()));
+            setText(0, pqFormatPageName(fPage));
             setIcon(0, QIcon(":/img/page.png"));
             break;
     }
@@ -146,6 +157,12 @@ bool QPlasmaTreeItem::operator<(const QTreeWidgetItem& other) const
         // sort class type folders by the numeric type ID.
         auto otherPlasma = static_cast<const QPlasmaTreeItem&>(other);
         return fClassType < otherPlasma.fClassType;
+    } else if (s_showAgePageIDs && type() == kTypePage && other.type() == kTypePage) {
+        // If age/page IDs are shown,
+        // sort pages by their location
+        // (i. e. first by age ID, then by page ID).
+        auto otherPlasma = static_cast<const QPlasmaTreeItem&>(other);
+        return fPage->getLocation() < otherPlasma.fPage->getLocation();
     } else if (type() != other.type()) {
         // Sort items of different types by their type,
         // i. e. group items of the same type together.

--- a/src/PrpShop/QPlasmaTreeItem.cpp
+++ b/src/PrpShop/QPlasmaTreeItem.cpp
@@ -20,83 +20,98 @@
 QPlasmaTreeItem::QPlasmaTreeItem()
     : QTreeWidgetItem(kTypeNone)
 {
-    setIcon(0, QIcon(":/img/folder.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(plKey obj)
-    : QTreeWidgetItem(kTypeKO), fObjKey(obj)
+    : QTreeWidgetItem(kTypeKO), fObjKey(std::move(obj))
 {
-    setText(0, st2qstr(obj->getName()));
-    setIcon(0, pqGetTypeIcon(obj->getType()));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(const QString& age)
     : QTreeWidgetItem(kTypeAge), fHasBuiltIn(false), fHasTextures(false),
       fAge(age)
 {
-    setText(0, age);
-    setIcon(0, QIcon(":/img/age.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(plPageInfo* page)
     : QTreeWidgetItem(kTypePage), fPage(page)
 {
-    setText(0, st2qstr(page->getPage()));
-    setIcon(0, QIcon(":/img/page.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent)
     : QTreeWidgetItem(parent, kTypeNone)
 {
-    setIcon(0, QIcon(":/img/folder.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, plKey obj)
-    : QTreeWidgetItem(parent, kTypeKO), fObjKey(obj)
+    : QTreeWidgetItem(parent, kTypeKO), fObjKey(std::move(obj))
 {
-    setText(0, st2qstr(obj->getName()));
-    setIcon(0, pqGetTypeIcon(obj->getType()));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, const QString& age)
     : QTreeWidgetItem(parent, kTypeAge), fHasBuiltIn(false),
       fHasTextures(false), fAge(age)
 {
-    setText(0, age);
-    setIcon(0, QIcon(":/img/age.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidget* parent, plPageInfo* page)
     : QTreeWidgetItem(parent, kTypePage), fPage(page)
 {
-    setText(0, st2qstr(page->getPage()));
-    setIcon(0, QIcon(":/img/page.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent)
     : QTreeWidgetItem(parent, kTypeNone)
 {
-    setIcon(0, QIcon(":/img/folder.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, plKey obj)
-    : QTreeWidgetItem(parent, kTypeKO), fObjKey(obj)
+    : QTreeWidgetItem(parent, kTypeKO), fObjKey(std::move(obj))
 {
-    setText(0, st2qstr(obj->getName()));
-    setIcon(0, pqGetTypeIcon(obj->getType()));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age)
     : QTreeWidgetItem(parent, kTypeAge), fHasBuiltIn(false),
       fHasTextures(false), fAge(age)
 {
-    setText(0, age);
-    setIcon(0, QIcon(":/img/age.png"));
+    reinit();
 }
 
 QPlasmaTreeItem::QPlasmaTreeItem(QTreeWidgetItem* parent, plPageInfo* page)
     : QTreeWidgetItem(parent, kTypePage), fPage(page)
 {
-    setText(0, st2qstr(page->getPage()));
-    setIcon(0, QIcon(":/img/page.png"));
+    reinit();
+}
+
+void QPlasmaTreeItem::reinit()
+{
+    switch (type()) {
+        case kTypeNone:
+            setIcon(0, QIcon(":/img/folder.png"));
+            break;
+
+        case kTypeKO:
+            setText(0, st2qstr(fObjKey->getName()));
+            setIcon(0, pqGetTypeIcon(fObjKey->getType()));
+            break;
+
+        case kTypeAge:
+            setText(0, fAge);
+            setIcon(0, QIcon(":/img/age.png"));
+            break;
+
+        case kTypePage:
+            setText(0, st2qstr(fPage->getPage()));
+            setIcon(0, QIcon(":/img/page.png"));
+            break;
+    }
 }

--- a/src/PrpShop/QPlasmaTreeItem.cpp
+++ b/src/PrpShop/QPlasmaTreeItem.cpp
@@ -138,3 +138,23 @@ void QPlasmaTreeItem::reinit()
             break;
     }
 }
+
+bool QPlasmaTreeItem::operator<(const QTreeWidgetItem& other) const
+{
+    if (s_showTypeIDs && type() == kTypeClassType && other.type() == kTypeClassType) {
+        // If type IDs are shown,
+        // sort class type folders by the numeric type ID.
+        auto otherPlasma = static_cast<const QPlasmaTreeItem&>(other);
+        return fClassType < otherPlasma.fClassType;
+    } else if (type() != other.type()) {
+        // Sort items of different types by their type,
+        // i. e. group items of the same type together.
+        // (This ensures a consistent sort order in case items of different types
+        // with special sorting behavior somehow end up in the same list.)
+        return type() < other.type();
+    } else {
+        // If both items have the same type, but the type has no special sorting behavior,
+        // fall back to default sorting by text.
+        return QTreeWidgetItem::operator<(other);
+    }
+}

--- a/src/PrpShop/QPlasmaTreeItem.cpp
+++ b/src/PrpShop/QPlasmaTreeItem.cpp
@@ -156,6 +156,10 @@ void QPlasmaTreeItem::reinit()
             setText(0, pqFormatPageName(fPage));
             setIcon(0, QIcon(":/img/page.png"));
             break;
+
+        default:
+            setText(0, QString("[Error: unhandled item type %1]").arg(type()));
+            setIcon(0, QIcon());
     }
 }
 

--- a/src/PrpShop/QPlasmaTreeItem.h
+++ b/src/PrpShop/QPlasmaTreeItem.h
@@ -51,6 +51,8 @@ public:
     QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age);
     QPlasmaTreeItem(QTreeWidgetItem* parent, plPageInfo* page);
 
+    void reinit();
+
     hsKeyedObject* obj() const { return (type() == kTypeKO) ? fObjKey->getObj() : NULL; }
     QString age() const { return (type() == kTypeAge) ? fAge : QString(); }
     plPageInfo* page() const { return (type() == kTypePage) ? fPage : NULL; }

--- a/src/PrpShop/QPlasmaTreeItem.h
+++ b/src/PrpShop/QPlasmaTreeItem.h
@@ -57,6 +57,8 @@ public:
 
     void reinit();
 
+    bool operator<(const QTreeWidgetItem& other) const override;
+
     hsKeyedObject* obj() const { return (type() == kTypeKO) ? fObjKey->getObj() : NULL; }
     short classType() const { return (type() == kTypeClassType) ? fClassType : static_cast<short>(0x8000); }
     QString age() const { return (type() == kTypeAge) ? fAge : QString(); }

--- a/src/PrpShop/QPlasmaTreeItem.h
+++ b/src/PrpShop/QPlasmaTreeItem.h
@@ -29,6 +29,7 @@ private:
     plPageInfo* fPage;
     bool fHasBuiltIn, fHasTextures;
     QString fAge;
+    int fAgeSeqPrefix;
 
     QString fFilename;
 
@@ -42,17 +43,17 @@ public:
     QPlasmaTreeItem();
     QPlasmaTreeItem(plKey obj);
     QPlasmaTreeItem(short classType);
-    QPlasmaTreeItem(const QString& age);
+    QPlasmaTreeItem(const QString& age, int ageSeqPrefix);
     QPlasmaTreeItem(plPageInfo* page);
     QPlasmaTreeItem(QTreeWidget* parent);
     QPlasmaTreeItem(QTreeWidget* parent, plKey obj);
     QPlasmaTreeItem(QTreeWidget* parent, short classType);
-    QPlasmaTreeItem(QTreeWidget* parent, const QString& age);
+    QPlasmaTreeItem(QTreeWidget* parent, const QString& age, int ageSeqPrefix);
     QPlasmaTreeItem(QTreeWidget* parent, plPageInfo* page);
     QPlasmaTreeItem(QTreeWidgetItem* parent);
     QPlasmaTreeItem(QTreeWidgetItem* parent, plKey obj);
     QPlasmaTreeItem(QTreeWidgetItem* parent, short classType);
-    QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age);
+    QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age, int ageSeqPrefix);
     QPlasmaTreeItem(QTreeWidgetItem* parent, plPageInfo* page);
 
     void reinit();
@@ -62,6 +63,7 @@ public:
     hsKeyedObject* obj() const { return (type() == kTypeKO) ? fObjKey->getObj() : NULL; }
     short classType() const { return (type() == kTypeClassType) ? fClassType : static_cast<short>(0x8000); }
     QString age() const { return (type() == kTypeAge) ? fAge : QString(); }
+    int ageSeqPrefix() const { return (type() == kTypeAge) ? fAgeSeqPrefix : INT_MIN; }
     plPageInfo* page() const { return (type() == kTypePage) ? fPage : NULL; }
 
     bool hasBuiltIn() const { return (type() == kTypeAge) ? fHasBuiltIn : false; }

--- a/src/PrpShop/QPlasmaTreeItem.h
+++ b/src/PrpShop/QPlasmaTreeItem.h
@@ -25,6 +25,7 @@ class QPlasmaTreeItem : public QTreeWidgetItem
 {
 private:
     plKey fObjKey;
+    short fClassType;
     plPageInfo* fPage;
     bool fHasBuiltIn, fHasTextures;
     QString fAge;
@@ -34,26 +35,30 @@ private:
 public:
     enum ItemType
     {
-        kTypeNone = QTreeWidgetItem::UserType, kTypeAge, kTypePage, kTypeKO,
+        kTypeNone = QTreeWidgetItem::UserType, kTypeAge, kTypePage, kTypeClassType, kTypeKO,
         kMaxPlasmaTypes
     };
 
     QPlasmaTreeItem();
     QPlasmaTreeItem(plKey obj);
+    QPlasmaTreeItem(short classType);
     QPlasmaTreeItem(const QString& age);
     QPlasmaTreeItem(plPageInfo* page);
     QPlasmaTreeItem(QTreeWidget* parent);
     QPlasmaTreeItem(QTreeWidget* parent, plKey obj);
+    QPlasmaTreeItem(QTreeWidget* parent, short classType);
     QPlasmaTreeItem(QTreeWidget* parent, const QString& age);
     QPlasmaTreeItem(QTreeWidget* parent, plPageInfo* page);
     QPlasmaTreeItem(QTreeWidgetItem* parent);
     QPlasmaTreeItem(QTreeWidgetItem* parent, plKey obj);
+    QPlasmaTreeItem(QTreeWidgetItem* parent, short classType);
     QPlasmaTreeItem(QTreeWidgetItem* parent, const QString& age);
     QPlasmaTreeItem(QTreeWidgetItem* parent, plPageInfo* page);
 
     void reinit();
 
     hsKeyedObject* obj() const { return (type() == kTypeKO) ? fObjKey->getObj() : NULL; }
+    short classType() const { return (type() == kTypeClassType) ? fClassType : static_cast<short>(0x8000); }
     QString age() const { return (type() == kTypeAge) ? fAge : QString(); }
     plPageInfo* page() const { return (type() == kTypePage) ? fPage : NULL; }
 

--- a/src/PrpShop/QPlasmaUtils.cpp
+++ b/src/PrpShop/QPlasmaUtils.cpp
@@ -21,6 +21,7 @@
 #include <PRP/Object/plCoordinateInterface.h>
 #include <PRP/Object/plSceneObject.h>
 
+bool s_showAgePageIDs = false;
 bool s_showTypeIDs = false;
 
 enum

--- a/src/PrpShop/QPlasmaUtils.h
+++ b/src/PrpShop/QPlasmaUtils.h
@@ -24,6 +24,7 @@
 #include "QPlasma.h"
 #include "QNumerics.h"
 
+extern bool s_showAgePageIDs;
 extern bool s_showTypeIDs;
 
 enum


### PR DESCRIPTION
Supersedes #78. Adds an option to display age/page IDs next to page names, similar to the existing option to display type IDs next to class names.

![Screenshot of Tools menu and Object Browser with age/page IDs shown](https://github.com/H-uru/PlasmaShop/assets/6641959/0a30d715-9dc7-4546-914a-85fe4e129f84)