### PR TITLE
OpenGL & Linux CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,12 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libkf5syntaxhighlighting-dev ninja-build qtbase5-dev
+          sudo apt-get install -y \
+              libjpeg-turbo8-dev \
+              libkf5syntaxhighlighting-dev \
+              libpng-dev \
+              ninja-build \
+              qtbase5-dev
 
       - name: Checkout string_theory
         uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,10 @@ find_package(string_theory 2.0 REQUIRED)
 if(NOT DEFINED QT_VERSION_MAJOR)
     find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
 endif()
-find_package(Qt${QT_VERSION_MAJOR} 5.10 REQUIRED COMPONENTS Core Widgets)
+find_package(Qt${QT_VERSION_MAJOR} 5.10 REQUIRED COMPONENTS Core Widgets OpenGL)
 if(Qt5_FOUND AND NOT TARGET Qt::Core)
     # The version-generic targets were only added in Qt 5.15
-    foreach(_qt_lib Core Widgets)
+    foreach(_qt_lib Core Widgets OpenGL)
         add_library(Qt::${_qt_lib} INTERFACE IMPORTED)
         set_target_properties(Qt::${_qt_lib} PROPERTIES
                 INTERFACE_LINK_LIBRARIES "Qt5::${_qt_lib}")

--- a/src/PrpShop/CMakeLists.txt
+++ b/src/PrpShop/CMakeLists.txt
@@ -153,16 +153,13 @@ include_directories("${PROJECT_SOURCE_DIR}/src/PrpShop")
 # QtOpenGL dependencies (maybe the Qt OpenGL cmake stuff is broken, but I had
 # to copy this here from Qt4ConfigDependentSettings.cmake)
 find_package(OpenGL)
-set(QT_QTOPENGL_LIB_DEPENDENCIES ${OPENGL_glu_LIBRARY} ${OPENGL_gl_LIBRARY})
 
 add_executable(PrpShop WIN32 MACOSX_BUNDLE
                ${PrpShop_Sources} ${PrpShop_Headers} ${PrpShop_QRC})
-target_link_libraries(PrpShop PSCommon Qt::Core Qt::Widgets)
+target_link_libraries(PrpShop PSCommon HSPlasma OpenGL::GL Qt::Core Qt::Widgets Qt::OpenGL)
 if(QT_VERSION_MAJOR VERSION_GREATER_EQUAL 6)
     target_link_libraries(PrpShop Qt::OpenGLWidgets)
 endif()
-target_link_libraries(PrpShop HSPlasma)
-target_link_libraries(PrpShop ${QT_QTOPENGL_LIB_DEPENDENCIES})
 
 if(APPLE)
     set(MACOSX_BUNDLE true)

--- a/src/PrpShop/PRP/Render/QPlasmaRender.cpp
+++ b/src/PrpShop/PRP/Render/QPlasmaRender.cpp
@@ -16,9 +16,6 @@
 
 #include "QPlasmaRender.h"
 
-#include <GL/gl.h>
-#include <GL/glu.h>
-#include <GL/glext.h>
 #include <Debug/plDebug.h>
 #include <PRP/Surface/plLayer.h>
 #include <PRP/Surface/plCubicEnvironmap.h>
@@ -116,6 +113,8 @@ QActionGroup* QPlasmaRender::createViewActions()
 
 void QPlasmaRender::initializeGL()
 {
+    initializeOpenGLFunctions();
+
     glShadeModel(GL_SMOOTH);
     glClearDepth(1.0f);
     glEnable(GL_DEPTH_TEST);
@@ -139,7 +138,17 @@ void QPlasmaRender::resizeGL(int width, int height)
     glViewport(0, 0, width, height);
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    gluPerspective(45.0f, (float)width/(float)height, 0.001f, 20000.0f);
+
+    // Below is essentially the implementation of
+    // gluPerspective(45.0f, (float)width/(float)height, 0.001f, 20000.0f);
+
+    GLdouble xmin, xmax, ymin, ymax;
+    ymax = 0.001f; // * tan(45.f degrees) which == 1
+    ymin = -ymax;
+    xmin = ymin * ((float)width/(float)height);
+    xmax = ymax * ((float)width/(float)height);
+
+    glFrustum(xmin, xmax, ymin, ymax, 0.001f, 20000.0f);
 }
 
 void QPlasmaRender::paintGL()

--- a/src/PrpShop/PRP/Render/QPlasmaRender.h
+++ b/src/PrpShop/PRP/Render/QPlasmaRender.h
@@ -25,7 +25,7 @@
 
 #include "QTrackball.h"
 
-class QPlasmaRender : public QOpenGLWidget
+class QPlasmaRender : public QOpenGLWidget, protected QOpenGLFunctions
 {
     Q_OBJECT
 


### PR DESCRIPTION
* Linux CI was failing on the newer ubuntu-24.04 runners because libjpeg and libpng need to be installed

* Was getting weird link errors from OpenGL on Linux CI as well, so I tried moving to letting Qt handle all the OpenGL function stuff, but that still wasn't working. Seems the actual solution is to use the `OpenGL::GL` module in CMake rather than the `OPENGL_gl_LIBRARY` 🤷🏼‍♂️ 
  I can undo the Qt changes if we prefer to keep it as it was