### PR TITLE
macOS Fixes

### DIFF
--- a/src/PlasmaShop/Main.cpp
+++ b/src/PlasmaShop/Main.cpp
@@ -1416,6 +1416,9 @@ int main(int argc, char* argv[])
     plDebug::InitFile(plDebug::kDLAll, logpath.toUtf8().constData());
 
     QApplication app(argc, argv);
+#ifdef Q_OS_MAC
+    app.setAttribute(Qt::AA_DontUseNativeDialogs, true);
+#endif
 
     // Set this at the very beginning, so it can be re-used in case the
     // application's CWD changes

--- a/src/PrpShop/Main.cpp
+++ b/src/PrpShop/Main.cpp
@@ -1221,6 +1221,9 @@ int main(int argc, char* argv[])
     plDebug::InitFile(plDebug::kDLAll, logpath.toUtf8().constData());
 
     QApplication app(argc, argv);
+#ifdef Q_OS_MAC
+    app.setAttribute(Qt::AA_DontUseNativeDialogs, true);
+#endif
     PrpShopMain mainWnd;
     mainWnd.show();
     for (int i=1; i<argc; i++)

--- a/src/PrpShop/PRP/Render/QPlasmaRender.cpp
+++ b/src/PrpShop/PRP/Render/QPlasmaRender.cpp
@@ -28,7 +28,9 @@
 #include <cmath>
 #include "QPlasmaUtils.h"
 
-PFNGLCOMPRESSEDTEXIMAGE2DARBPROC glCompressedTexImage2DARB = NULL;
+#ifndef Q_OS_MAC
+    PFNGLCOMPRESSEDTEXIMAGE2DARBPROC glCompressedTexImage2DARB = NULL;
+#endif
 
 void QPlasmaRender::ObjectInfo::setList(DrawMode mode, int32_t value)
 {
@@ -121,8 +123,10 @@ void QPlasmaRender::initializeGL()
     glDepthFunc(GL_LEQUAL);
     glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
 
+#ifndef Q_OS_MAC
     if (glCompressedTexImage2DARB == NULL)
         glCompressedTexImage2DARB = (PFNGLCOMPRESSEDTEXIMAGE2DARBPROC)context()->getProcAddress("glCompressedTexImage2DARB");
+#endif
 
     fTexList = new GLuint[fTexCount];
     glGenTextures(fTexCount, fTexList);

--- a/src/VaultShop/Main.cpp
+++ b/src/VaultShop/Main.cpp
@@ -770,6 +770,9 @@ int main(int argc, char* argv[])
     plDebug::InitFile(plDebug::kDLAll, logpath.toUtf8().constData());
 
     QApplication app(argc, argv);
+#ifdef Q_OS_MAC
+    app.setAttribute(Qt::AA_DontUseNativeDialogs, true);
+#endif
     VaultShopMain mainWnd;
     if (argc > 1 && QFile::exists(argv[1]))
         mainWnd.loadGame(argv[1]);


### PR DESCRIPTION
* `glCompressedTexImage2DARB` is declared in the OpenGL framework's GL.h header on macOS, and `PFNGLCOMPRESSEDTEXIMAGE2DARBPROC` is not

* Open and Save dialogs were never appearing for me with Qt 6.9.0. I couldn't find a bug report in Qt about this, but telling it not to use the native platform dialogs works around the issue. (Unsure if this is specific to Qt6 or if it also affects Qt5, or related to OS version, or what...)